### PR TITLE
Login redirect

### DIFF
--- a/src/actions/session.test.ts
+++ b/src/actions/session.test.ts
@@ -1,26 +1,183 @@
 import * as chai from "chai";
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
+import * as sinon from "sinon";
 
 import { SET_USER } from "../constants";
 import User from "../models/user";
+import auth from "../services/auth";
 import * as session from "./session";
 
-const middlewares = [ thunk ];
+
+const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 
 let expect = chai.expect;
 
-describe("Session Actions", function () {
-    it("sets the user", function() {
-        let user = new User({ email: "email"});
-        let initialState = {};
+describe("Session.ts", function () {
+    describe("Session Actions", function () {
+        it("sets the user", function () {
+            let user = new User({ email: "email" });
+            let initialState = {};
 
-        let store = mockStore(initialState);
-        store.dispatch(session.setUser(user));
+            let store = mockStore(initialState);
+            store.dispatch(session.setUser(user));
 
-        expect(store.getActions().length).to.equal(1);
-        let action: any = store.getActions()[0];
-        expect(action.type).to.equal(SET_USER);
+            expect(store.getActions().length).to.equal(1);
+            let action: any = store.getActions()[0];
+            expect(action.type).to.equal(SET_USER);
+        });
     });
+
+    describe("ToPath callbacks", function() {
+        it ("Tests the toPath callback to ensure it goes to the appropriate location.", function() {
+            // The callback should replace the current page to the base page "/TestPath".
+            let callback = new session.ToPathCallback("/TestPath");
+            let initialState = {};
+            let store = mockStore(initialState);
+
+            callback.loginSuccess(store.dispatch, new User({email: "email"}));
+
+            expect(store.getActions().length).to.equal(1);
+
+            let action: any = store.getActions()[0];
+            expect(action.payload.method).to.equal("replace"); // This is redux-route method which could change as that library changes.
+            expect(action.payload.args[0]).to.equal("/TestPath");
+        });
+    });
+
+    describe("Back callback", function() {
+        it ("Tests the Back method actually goes back to the previous age.", function() {
+            // The callback should perform a "back" option.
+            let callback = new session.BackCallback();
+            let initialState = {};
+            let store = mockStore(initialState);
+
+            callback.loginSuccess(store.dispatch, new User({email: "email"}));
+
+            expect(store.getActions().length).to.equal(1);
+
+            let action: any = store.getActions()[0];
+            expect(action.payload.method).to.equal("goBack"); // This is redux-route method which could change as that library changes.
+        });
+    });
+
+    describe("Login With Github", function() {
+
+        let loginGithubStub: Sinon.SinonStub;
+        let setUserStub: Sinon.SinonStub;
+
+        before("Stubbing auth namespace.", function() {
+            loginGithubStub = sinon.stub(auth, "loginWithGithub", (callback: (success: boolean, error?: string) => void) => {
+                callback(true, undefined);
+            });
+
+            setUserStub = sinon.stub(auth, "user", () => {
+                return new User({ email: "testEmail" });
+            });
+        });
+
+        after(function() {
+            loginGithubStub.restore();
+            setUserStub.restore();
+        });
+
+        it ("Tests the login flow works properly on a successful github login with a default login strategy.", function() {
+            let initialState = {};
+            let store = mockStore(initialState);
+
+            let loginMethod = session.loginWithGithub();
+            loginMethod(store.dispatch);
+
+            expect(store.getActions().length).to.greaterThan(0);
+
+            // TODO: Right now these are assuming that the "setUserAction" and the "redirectAction" are the last two
+            // actions being dispatched, but really what's important is that "setUser" is before the "redirect". This can be
+            // generic.
+            let setUserAction: any = store.getActions()[store.getActions().length - 2];
+            let redirectAction: any = store.getActions()[store.getActions().length - 1];
+
+            verifyUserAction(setUserAction);
+            verifyReplaceAction(redirectAction, "/");
+        });
+
+        it ("Tests the login flow works properly on successful github login with overridden login strategy.", function() {
+            let initialState = {};
+            let store = mockStore(initialState);
+
+            session.loginWithGithub(new session.ToPathCallback("/NextPath"))(store.dispatch);
+
+            expect(store.getActions().length).to.greaterThan(0);
+
+            let setUserAction: any = store.getActions()[store.getActions().length - 2];
+            let redirectAction: any = store.getActions()[store.getActions().length - 1];
+
+            verifyUserAction(setUserAction);
+            verifyReplaceAction(redirectAction, "/NextPath");
+        });
+    });
+
+    describe("login with username and password", function() {
+
+        let loginStub: Sinon.SinonStub;
+        let setUserStub: Sinon.SinonStub;
+
+        before("Stubbing auth namespace.", function() {
+            loginStub = sinon.stub(auth, "login", (email: string, password: string, callback: (success: boolean, error?: string) => void) => {
+                callback(true, undefined);
+            });
+
+            setUserStub = sinon.stub(auth, "user", () => {
+                return new User({ email: "testEmail" });
+            });
+        });
+
+        after(function() {
+            loginStub.restore();
+            setUserStub.restore();
+        });
+
+        it ("Tests the login flow works properly on a successful username and password login with a default login strategy.", function() {
+            let initialState = {};
+            let store = mockStore(initialState);
+
+            session.login("testuser", "secretPassword")(store.dispatch);
+
+            expect(store.getActions().length).to.greaterThan(0);
+
+            // TODO: Right now these are assuming that the "setUserAction" and the "redirectAction" are the last two
+            // actions being dispatched, but really what's important is that "setUser" is before the "redirect". This can be
+            // generic.
+            let setUserAction: any = store.getActions()[store.getActions().length - 2];
+            let redirectAction: any = store.getActions()[store.getActions().length - 1];
+
+            verifyUserAction(setUserAction);
+            verifyReplaceAction(redirectAction, "/");
+        });
+
+        it ("Tests the login flow works properly on successful username and password login with overridden login strategy.", function() {
+            let initialState = {};
+            let store = mockStore(initialState);
+
+            session.login("testuser", "secretPassword", new session.ToPathCallback("/NextPath"))(store.dispatch);
+
+            expect(store.getActions().length).to.greaterThan(0);
+
+            let setUserAction: any = store.getActions()[store.getActions().length - 2];
+            let redirectAction: any = store.getActions()[store.getActions().length - 1];
+
+            verifyUserAction(setUserAction);
+            verifyReplaceAction(redirectAction, "/NextPath");
+        });
+    });
+
+    function verifyUserAction(action: any) {
+        expect(action.type).to.equal(SET_USER);
+        expect(action.user.email).to.equal("testEmail");
+    }
+
+    function verifyReplaceAction(action: any, path: string) {
+        expect(action.payload.method).to.equal("replace"); // This is redux-route method which could change as that library changes.
+        expect(action.payload.args[0]).to.equal(path);
+    }
 });

--- a/src/actions/session.test.ts
+++ b/src/actions/session.test.ts
@@ -83,37 +83,15 @@ describe("Session.ts", function () {
         });
 
         it ("Tests the login flow works properly on a successful github login with a default login strategy.", function() {
-            let initialState = {};
-            let store = mockStore(initialState);
-
-            let loginMethod = session.loginWithGithub();
-            loginMethod(store.dispatch);
-
-            expect(store.getActions().length).to.greaterThan(0);
-
-            // TODO: Right now these are assuming that the "setUserAction" and the "redirectAction" are the last two
-            // actions being dispatched, but really what's important is that "setUser" is before the "redirect". This can be
-            // generic.
-            let setUserAction: any = store.getActions()[store.getActions().length - 2];
-            let redirectAction: any = store.getActions()[store.getActions().length - 1];
-
-            verifyUserAction(setUserAction);
-            verifyReplaceAction(redirectAction, "/");
+            verifySuccessLogin("/", (store: any) => {
+                session.loginWithGithub()(store.dispatch);
+            });
         });
 
         it ("Tests the login flow works properly on successful github login with overridden login strategy.", function() {
-            let initialState = {};
-            let store = mockStore(initialState);
-
-            session.loginWithGithub(new session.ToPathCallback("/NextPath"))(store.dispatch);
-
-            expect(store.getActions().length).to.greaterThan(0);
-
-            let setUserAction: any = store.getActions()[store.getActions().length - 2];
-            let redirectAction: any = store.getActions()[store.getActions().length - 1];
-
-            verifyUserAction(setUserAction);
-            verifyReplaceAction(redirectAction, "/NextPath");
+            verifySuccessLogin("/NextPath", (store: any) => {
+                session.loginWithGithub(new session.ToPathCallback("/NextPath"))(store.dispatch);
+            });
         });
     });
 
@@ -138,38 +116,35 @@ describe("Session.ts", function () {
         });
 
         it ("Tests the login flow works properly on a successful username and password login with a default login strategy.", function() {
-            let initialState = {};
-            let store = mockStore(initialState);
-
-            session.login("testuser", "secretPassword")(store.dispatch);
-
-            expect(store.getActions().length).to.greaterThan(0);
-
-            // TODO: Right now these are assuming that the "setUserAction" and the "redirectAction" are the last two
-            // actions being dispatched, but really what's important is that "setUser" is before the "redirect". This can be
-            // generic.
-            let setUserAction: any = store.getActions()[store.getActions().length - 2];
-            let redirectAction: any = store.getActions()[store.getActions().length - 1];
-
-            verifyUserAction(setUserAction);
-            verifyReplaceAction(redirectAction, "/");
+            verifySuccessLogin("/", (store: any) => {
+                session.login("testuser", "secretPassword")(store.dispatch);
+            });
         });
 
         it ("Tests the login flow works properly on successful username and password login with overridden login strategy.", function() {
-            let initialState = {};
-            let store = mockStore(initialState);
-
-            session.login("testuser", "secretPassword", new session.ToPathCallback("/NextPath"))(store.dispatch);
-
-            expect(store.getActions().length).to.greaterThan(0);
-
-            let setUserAction: any = store.getActions()[store.getActions().length - 2];
-            let redirectAction: any = store.getActions()[store.getActions().length - 1];
-
-            verifyUserAction(setUserAction);
-            verifyReplaceAction(redirectAction, "/NextPath");
+            verifySuccessLogin("/NextPath", (store: any) => {
+                session.login("testuser", "secretPassword", new session.ToPathCallback("/NextPath"))(store.dispatch);
+            });
         });
     });
+
+    function verifySuccessLogin(redirectPath: string, loginAction: (store: any) => void) {
+        let initialState = {};
+        let store = mockStore(initialState);
+
+        loginAction(store);
+
+        expect(store.getActions().length).to.greaterThan(0);
+
+        // TODO: Right now these are assuming that the "setUserAction" and the "redirectAction" are the last two
+        // actions being dispatched, but really what's important is that "setUser" is before the "redirect". This can be
+        // generic.
+        let setUserAction: any = store.getActions()[store.getActions().length - 2];
+        let redirectAction: any = store.getActions()[store.getActions().length - 1];
+
+        verifyUserAction(setUserAction);
+        verifyReplaceAction(redirectAction, redirectPath);
+    }
 
     function verifyUserAction(action: any) {
         expect(action.type).to.equal(SET_USER);

--- a/src/actions/session.ts
+++ b/src/actions/session.ts
@@ -1,4 +1,4 @@
-import { push } from "react-router-redux";
+import { replace } from "react-router-redux";
 
 import { SENDING_REQUEST, SET_USER } from "../constants";
 import User from "../models/user";
@@ -24,7 +24,7 @@ export interface RedirectStrategy {
 
 class DefaultRedirectStrategy implements RedirectStrategy {
   loginSuccess(dispatch: Redux.Dispatch<any>, user: User): void {
-    dispatch(push("/"));
+    dispatch(replace("/"));
   }
 };
 
@@ -60,7 +60,7 @@ export function logout() {
   return function (dispatch: Redux.Dispatch<any>) {
     auth.logout(function (success) {
       if (success) {
-        dispatch(push("/login"));
+        dispatch(replace("/login"));
       }
     });
   };

--- a/src/actions/session.ts
+++ b/src/actions/session.ts
@@ -18,42 +18,19 @@ export function setUser(user: User | undefined) {
   };
 }
 
+
 export function login(email: string, password: string) {
   return function (dispatch: Redux.Dispatch<any>) {
-
-    dispatch(sendingRequest(true));
-
-    auth.login(email, password, (success, error) => {
-
-      dispatch(sendingRequest(false));
-      dispatch(setUser(auth.user()));
-
-      if (success) {
-        dispatch(push("/"));
-      } else {
-        // clear the password
-        // set the error
-      }
+    loginMethod(dispatch, function(callback) {
+      auth.login(email, password, callback);
     });
   };
 }
 
 export function loginWithGithub() {
   return function (dispatch: Redux.Dispatch<any>) {
-
-    dispatch(sendingRequest(true));
-
-    auth.loginWithGithub(function(success, error) {
-
-      dispatch(sendingRequest(false));
-      dispatch(setUser(auth.user()));
-
-      if (success) {
-        dispatch(push("/"));
-      } else {
-        // clear the password
-        // set the error
-      }
+    loginMethod(dispatch, function(callback) {
+      auth.loginWithGithub(callback);
     });
   };
 }
@@ -66,4 +43,19 @@ export function logout() {
       }
     });
   };
+}
+
+function loginMethod(dispatch: Redux.Dispatch<any>, login: (callback: (success: boolean, error?: string) => void) => void) {
+  dispatch(sendingRequest(true));
+  login(function(success, error) {
+      dispatch(sendingRequest(false));
+      dispatch(setUser(auth.user()));
+
+      if (success) {
+        dispatch(push("/"));
+      } else {
+        // clear the password
+        // set the error
+      }
+  });
 }

--- a/src/actions/session.ts
+++ b/src/actions/session.ts
@@ -18,17 +18,17 @@ export function setUser(user: User | undefined) {
   };
 }
 
-export interface RedirectStrategy {
+export interface SuccessCallback {
   loginSuccess(dispatch: Redux.Dispatch<any>, user: User): void;
 }
 
-export class BackStrategy implements RedirectStrategy {
+export class BackStrategy implements SuccessCallback {
   loginSuccess(dispatch: Redux.Dispatch<any>, user: User): void {
     dispatch(goBack());
   }
 }
 
-export class ToPathStrategy implements RedirectStrategy {
+export class ToPathCallback implements SuccessCallback {
   toPath: string;
 
   public constructor(toPath: string) {
@@ -40,13 +40,13 @@ export class ToPathStrategy implements RedirectStrategy {
   }
 }
 
-class DefaultRedirectStrategy extends ToPathStrategy {
+class DefaultRedirectCallback extends ToPathCallback {
   constructor() {
     super("/");
   }
 };
 
-function loginMethod(dispatch: Redux.Dispatch<any>, redirectStrat: RedirectStrategy = new DefaultRedirectStrategy(), loginStrat: (callback: (success: boolean, error?: string) => void) => void) {
+function loginMethod(dispatch: Redux.Dispatch<any>, redirectStrat: SuccessCallback = new DefaultRedirectCallback(), loginStrat: (callback: (success: boolean, error?: string) => void) => void) {
   dispatch(sendingRequest(true));
   loginStrat(function (success, error) {
     dispatch(sendingRequest(false));
@@ -58,7 +58,7 @@ function loginMethod(dispatch: Redux.Dispatch<any>, redirectStrat: RedirectStrat
   });
 }
 
-export function login(email: string, password: string, redirectStrat?: RedirectStrategy) {
+export function login(email: string, password: string, redirectStrat?: SuccessCallback) {
   return function (dispatch: Redux.Dispatch<any>) {
     loginMethod(dispatch, redirectStrat, function (internalCallback) {
       auth.login(email, password, internalCallback);
@@ -66,7 +66,7 @@ export function login(email: string, password: string, redirectStrat?: RedirectS
   };
 }
 
-export function loginWithGithub(redirectStrat?: RedirectStrategy) {
+export function loginWithGithub(redirectStrat?: SuccessCallback) {
   return function (dispatch: Redux.Dispatch<any>) {
     loginMethod(dispatch, redirectStrat, function (internalCallback) {
       auth.loginWithGithub(internalCallback);

--- a/src/actions/session.ts
+++ b/src/actions/session.ts
@@ -22,9 +22,21 @@ export interface RedirectStrategy {
   loginSuccess(dispatch: Redux.Dispatch<any>, user: User): void;
 }
 
-class DefaultRedirectStrategy implements RedirectStrategy {
+export class ToPathStrategy implements RedirectStrategy {
+  toPath: string;
+
+  public constructor(toPath: string) {
+    this.toPath = toPath;
+  }
+
   loginSuccess(dispatch: Redux.Dispatch<any>, user: User): void {
-    dispatch(replace("/"));
+    dispatch(replace(this.toPath));
+  }
+}
+
+class DefaultRedirectStrategy extends ToPathStrategy {
+  constructor() {
+    super("/");
   }
 };
 

--- a/src/actions/session.ts
+++ b/src/actions/session.ts
@@ -1,4 +1,4 @@
-import { replace } from "react-router-redux";
+import { goBack, push, replace } from "react-router-redux";
 
 import { SENDING_REQUEST, SET_USER } from "../constants";
 import User from "../models/user";
@@ -20,6 +20,12 @@ export function setUser(user: User | undefined) {
 
 export interface RedirectStrategy {
   loginSuccess(dispatch: Redux.Dispatch<any>, user: User): void;
+}
+
+export class BackStrategy implements RedirectStrategy {
+  loginSuccess(dispatch: Redux.Dispatch<any>, user: User): void {
+    dispatch(goBack());
+  }
 }
 
 export class ToPathStrategy implements RedirectStrategy {
@@ -72,7 +78,7 @@ export function logout() {
   return function (dispatch: Redux.Dispatch<any>) {
     auth.logout(function (success) {
       if (success) {
-        dispatch(replace("/login"));
+        dispatch(push("/login"));
       }
     });
   };

--- a/src/actions/session.ts
+++ b/src/actions/session.ts
@@ -22,7 +22,7 @@ export interface SuccessCallback {
   loginSuccess(dispatch: Redux.Dispatch<any>, user: User): void;
 }
 
-export class BackStrategy implements SuccessCallback {
+export class BackCallback implements SuccessCallback {
   loginSuccess(dispatch: Redux.Dispatch<any>, user: User): void {
     dispatch(goBack());
   }

--- a/src/actions/session.ts
+++ b/src/actions/session.ts
@@ -23,25 +23,26 @@ export interface RedirectStrategy {
 }
 
 class DefaultRedirectStrategy implements RedirectStrategy {
-    loginSuccess(dispatch: Redux.Dispatch<any>, user: User): void {
-        dispatch(push("/"));
-    }
+  loginSuccess(dispatch: Redux.Dispatch<any>, user: User): void {
+    dispatch(push("/"));
+  }
 };
 
 function loginMethod(dispatch: Redux.Dispatch<any>, redirectStrat: RedirectStrategy = new DefaultRedirectStrategy(), loginStrat: (callback: (success: boolean, error?: string) => void) => void) {
   dispatch(sendingRequest(true));
-  loginStrat(function(success, error) {
-      dispatch(sendingRequest(false));
-      dispatch(setUser(auth.user()));
+  loginStrat(function (success, error) {
+    dispatch(sendingRequest(false));
+    dispatch(setUser(auth.user()));
 
-      if (success) {
-        redirectStrat.loginSuccess(dispatch, auth.user());
-      }
+    if (success) {
+      redirectStrat.loginSuccess(dispatch, auth.user());
+    }
   });
+}
 
 export function login(email: string, password: string, redirectStrat?: RedirectStrategy) {
   return function (dispatch: Redux.Dispatch<any>) {
-    loginMethod(dispatch, redirectStrat, function(internalCallback) {
+    loginMethod(dispatch, redirectStrat, function (internalCallback) {
       auth.login(email, password, internalCallback);
     });
   };
@@ -49,7 +50,7 @@ export function login(email: string, password: string, redirectStrat?: RedirectS
 
 export function loginWithGithub(redirectStrat?: RedirectStrategy) {
   return function (dispatch: Redux.Dispatch<any>) {
-    loginMethod(dispatch, redirectStrat, function(internalCallback) {
+    loginMethod(dispatch, redirectStrat, function (internalCallback) {
       auth.loginWithGithub(internalCallback);
     });
   };
@@ -57,7 +58,7 @@ export function loginWithGithub(redirectStrat?: RedirectStrategy) {
 
 export function logout() {
   return function (dispatch: Redux.Dispatch<any>) {
-    auth.logout(function(success) {
+    auth.logout(function (success) {
       if (success) {
         dispatch(push("/login"));
       }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -48,11 +48,12 @@ Firebase.auth().onAuthStateChanged(function(user: Firebase.User) {
  * See below on the onEnter method.
  */
 let checkAuth: EnterHook = function(nextState: RouterState, replace: RedirectFunction) {
-
-    // TODO: make this type safe
     const session: any = store.getState().session;
     if (!session.user) {
-        replace("/login");
+        replace({
+            pathname: "/login",
+            state: { nextPathName: nextState.location.pathname }
+        });
     }
 };
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { connect } from "react-redux";
 
 import { changeForm } from "../actions/authForm";
-import { login, loginWithGithub } from "../actions/session";
+import { login, loginWithGithub, ToPathStrategy } from "../actions/session";
 import AuthForm from "../components/AuthForm";
 import Card from "../components/Card";
 import { Cell, Grid } from "../components/Grid";
@@ -13,9 +13,10 @@ interface LoginPageProps {
     email: string;
     password: string;
     error: string;
+    redirect?: string;
     changeForm: (field: string, value: string) => void;
-    login: (email: string, password: string) => (dispatch: Redux.Dispatch<any>) => void;
-    loginWithGithub: () => (dispatch: Redux.Dispatch<any>) => void;
+    login: (email: string, password: string, redirect?: string) => (dispatch: Redux.Dispatch<any>) => void;
+    loginWithGithub: (redirect?: string) => (dispatch: Redux.Dispatch<any>) => void;
 };
 
 function mapStateToProps(state: State.All) {
@@ -31,11 +32,13 @@ function mapDispatchToProps(dispatch: Redux.Dispatch<any>) {
         changeForm: function(field: string, value: string) {
             dispatch(changeForm(field, value));
         } ,
-        login: function(email: string, password: string) {
-            return dispatch(login(email, password));
+        login: function(email: string, password: string, origin?: string) {
+            let strat: ToPathStrategy = (origin) ? new ToPathStrategy(origin) : undefined;
+            return dispatch(login(email, password, strat));
         },
-        loginWithGithub: function() {
-            return dispatch(loginWithGithub());
+        loginWithGithub: function(origin?: string) {
+            let strat: ToPathStrategy = (origin) ? new ToPathStrategy(origin) : undefined;
+            return dispatch(loginWithGithub(strat));
         }
     };
 }
@@ -51,12 +54,12 @@ export class LoginPage extends React.Component<LoginPageProps, any> {
 
     handleFormSubmit(event: React.FormEvent) {
         event.preventDefault();
-        this.props.login(this.props.email, this.props.password);
+        this.props.login(this.props.email, this.props.password, this.props.redirect);
     }
 
     handleFormLoginWithGithub(event: React.FormEvent) {
         event.preventDefault();
-        this.props.loginWithGithub();
+        this.props.loginWithGithub(this.props.redirect);
     }
 
     render() {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -13,11 +13,6 @@ interface LoginPageProps {
     email: string;
     password: string;
     error: string;
-    /**
-     * The redirect URL to send to after successful login. You can also input "back" to indicate that the
-     * login page should return to the page that sent it.
-     */
-    redirect?: string;
     changeForm: (field: string, value: string) => void;
     login: (email: string, password: string, redirectStrat: RedirectStrategy) => (dispatch: Redux.Dispatch<any>) => void;
     loginWithGithub: (redirectStrat: RedirectStrategy) => (dispatch: Redux.Dispatch<any>) => void;
@@ -65,12 +60,10 @@ export class LoginPage extends React.Component<LoginPageProps, any> {
     }
 
     getRedirectStrategy(): RedirectStrategy {
-        if (!this.props.redirect) {
+        if (!this.props.location.state || !this.props.location.state.nextPathName) {
             return undefined;
-        } else if (this.props.redirect === "back") {
-            return new BackStrategy();
         } else {
-            return new ToPathStrategy(this.props.redirect);
+            return new ToPathStrategy(this.props.location.state.nextPathName);
         }
     }
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -3,11 +3,21 @@ import * as React from "react";
 import { connect } from "react-redux";
 
 import { changeForm } from "../actions/authForm";
-import { BackStrategy, login, loginWithGithub, RedirectStrategy, ToPathStrategy } from "../actions/session";
+import { login, loginWithGithub, RedirectStrategy, ToPathStrategy } from "../actions/session";
 import AuthForm from "../components/AuthForm";
 import Card from "../components/Card";
 import { Cell, Grid } from "../components/Grid";
 import { State } from "../reducers";
+
+/**
+ * Configuration objects to pass in to the router when pushing or replacing this page on the router.
+ */
+export interface LoginConfig {
+    /**
+     * The next path to go to once logged in.
+     */
+    nextPathName?: string;
+}
 
 interface LoginPageProps {
     email: string;
@@ -16,6 +26,7 @@ interface LoginPageProps {
     changeForm: (field: string, value: string) => void;
     login: (email: string, password: string, redirectStrat: RedirectStrategy) => (dispatch: Redux.Dispatch<any>) => void;
     loginWithGithub: (redirectStrat: RedirectStrategy) => (dispatch: Redux.Dispatch<any>) => void;
+    location?: RoutingData.Location<LoginConfig>;
 };
 
 function mapStateToProps(state: State.All) {
@@ -60,7 +71,7 @@ export class LoginPage extends React.Component<LoginPageProps, any> {
     }
 
     getRedirectStrategy(): RedirectStrategy {
-        if (!this.props.location.state || !this.props.location.state.nextPathName) {
+        if (!this.props.location || !this.props.location.state || !this.props.location.state.nextPathName) {
             return undefined;
         } else {
             return new ToPathStrategy(this.props.location.state.nextPathName);

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { connect } from "react-redux";
 
 import { changeForm } from "../actions/authForm";
-import { login, loginWithGithub, RedirectStrategy, ToPathStrategy } from "../actions/session";
+import { login, loginWithGithub, SuccessCallback, ToPathCallback } from "../actions/session";
 import AuthForm from "../components/AuthForm";
 import Card from "../components/Card";
 import { Cell, Grid } from "../components/Grid";
@@ -24,8 +24,8 @@ interface LoginPageProps {
     password: string;
     error: string;
     changeForm: (field: string, value: string) => void;
-    login: (email: string, password: string, redirectStrat: RedirectStrategy) => (dispatch: Redux.Dispatch<any>) => void;
-    loginWithGithub: (redirectStrat: RedirectStrategy) => (dispatch: Redux.Dispatch<any>) => void;
+    login: (email: string, password: string, redirectStrat: SuccessCallback) => (dispatch: Redux.Dispatch<any>) => void;
+    loginWithGithub: (redirectStrat: SuccessCallback) => (dispatch: Redux.Dispatch<any>) => void;
     location?: RoutingData.Location<LoginConfig>;
 };
 
@@ -42,10 +42,10 @@ function mapDispatchToProps(dispatch: Redux.Dispatch<any>) {
         changeForm: function(field: string, value: string) {
             dispatch(changeForm(field, value));
         } ,
-        login: function(email: string, password: string, redirectStrat: RedirectStrategy) {
+        login: function(email: string, password: string, redirectStrat: SuccessCallback) {
             return dispatch(login(email, password, redirectStrat));
         },
-        loginWithGithub: function(redirectStrat: RedirectStrategy) {
+        loginWithGithub: function(redirectStrat: SuccessCallback) {
             return dispatch(loginWithGithub(redirectStrat));
         }
     };
@@ -70,11 +70,11 @@ export class LoginPage extends React.Component<LoginPageProps, any> {
         this.props.loginWithGithub(this.getRedirectStrategy());
     }
 
-    getRedirectStrategy(): RedirectStrategy {
+    getRedirectStrategy(): SuccessCallback {
         if (!this.props.location || !this.props.location.state || !this.props.location.state.nextPathName) {
             return undefined;
         } else {
-            return new ToPathStrategy(this.props.location.state.nextPathName);
+            return new ToPathCallback(this.props.location.state.nextPathName);
         }
     }
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { connect } from "react-redux";
 
 import { changeForm } from "../actions/authForm";
-import { login, loginWithGithub, ToPathStrategy } from "../actions/session";
+import { BackStrategy, login, loginWithGithub, RedirectStrategy } from "../actions/session";
 import AuthForm from "../components/AuthForm";
 import Card from "../components/Card";
 import { Cell, Grid } from "../components/Grid";
@@ -13,10 +13,10 @@ interface LoginPageProps {
     email: string;
     password: string;
     error: string;
-    redirect?: string;
+    goBack?: boolean;
     changeForm: (field: string, value: string) => void;
-    login: (email: string, password: string, redirect?: string) => (dispatch: Redux.Dispatch<any>) => void;
-    loginWithGithub: (redirect?: string) => (dispatch: Redux.Dispatch<any>) => void;
+    login: (email: string, password: string, redirectStrat: RedirectStrategy) => (dispatch: Redux.Dispatch<any>) => void;
+    loginWithGithub: (redirectStrat: RedirectStrategy) => (dispatch: Redux.Dispatch<any>) => void;
 };
 
 function mapStateToProps(state: State.All) {
@@ -32,13 +32,11 @@ function mapDispatchToProps(dispatch: Redux.Dispatch<any>) {
         changeForm: function(field: string, value: string) {
             dispatch(changeForm(field, value));
         } ,
-        login: function(email: string, password: string, origin?: string) {
-            let strat: ToPathStrategy = (origin) ? new ToPathStrategy(origin) : undefined;
-            return dispatch(login(email, password, strat));
+        login: function(email: string, password: string, redirectStrat: RedirectStrategy) {
+            return dispatch(login(email, password, redirectStrat));
         },
-        loginWithGithub: function(origin?: string) {
-            let strat: ToPathStrategy = (origin) ? new ToPathStrategy(origin) : undefined;
-            return dispatch(loginWithGithub(strat));
+        loginWithGithub: function(redirectStrat: RedirectStrategy) {
+            return dispatch(loginWithGithub(redirectStrat));
         }
     };
 }
@@ -54,12 +52,16 @@ export class LoginPage extends React.Component<LoginPageProps, any> {
 
     handleFormSubmit(event: React.FormEvent) {
         event.preventDefault();
-        this.props.login(this.props.email, this.props.password, this.props.redirect);
+        this.props.login(this.props.email, this.props.password, this.getRedirectStrategy());
     }
 
     handleFormLoginWithGithub(event: React.FormEvent) {
         event.preventDefault();
-        this.props.loginWithGithub(this.props.redirect);
+        this.props.loginWithGithub(this.getRedirectStrategy());
+    }
+
+    getRedirectStrategy(): RedirectStrategy {
+        return (this.props.goBack) ? new BackStrategy() : undefined;
     }
 
     render() {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { connect } from "react-redux";
 
 import { changeForm } from "../actions/authForm";
-import { BackStrategy, login, loginWithGithub, RedirectStrategy } from "../actions/session";
+import { BackStrategy, login, loginWithGithub, RedirectStrategy, ToPathStrategy } from "../actions/session";
 import AuthForm from "../components/AuthForm";
 import Card from "../components/Card";
 import { Cell, Grid } from "../components/Grid";
@@ -13,7 +13,11 @@ interface LoginPageProps {
     email: string;
     password: string;
     error: string;
-    goBack?: boolean;
+    /**
+     * The redirect URL to send to after successful login. You can also input "back" to indicate that the
+     * login page should return to the page that sent it.
+     */
+    redirect?: string;
     changeForm: (field: string, value: string) => void;
     login: (email: string, password: string, redirectStrat: RedirectStrategy) => (dispatch: Redux.Dispatch<any>) => void;
     loginWithGithub: (redirectStrat: RedirectStrategy) => (dispatch: Redux.Dispatch<any>) => void;
@@ -61,7 +65,13 @@ export class LoginPage extends React.Component<LoginPageProps, any> {
     }
 
     getRedirectStrategy(): RedirectStrategy {
-        return (this.props.goBack) ? new BackStrategy() : undefined;
+        if (!this.props.redirect) {
+            return undefined;
+        } else if (this.props.redirect === "back") {
+            return new BackStrategy();
+        } else {
+            return new ToPathStrategy(this.props.redirect);
+        }
     }
 
     render() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
   "include": [
     "src/**/*",
     "./typings/index.d.ts",
-    "./typings/react-json-tree.d.ts"
+    "./typings/react-json-tree.d.ts",
+    "./typings/routing-data.d.ts"
   ],
   "exclude": [
     "node_modules",

--- a/typings/routing-data.d.ts
+++ b/typings/routing-data.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Routing data objects that are appended to React.Component props objects through the
+ * react-router-redux reducers.
+ */
+
+declare namespace RoutingData {
+    export interface Location<S> {
+        action: string,
+        baseName: string,
+        hash: string,
+        key: string,
+        pathName: string,
+        state: S
+    }
+}


### PR DESCRIPTION
Fixes #39 

Changes in this pull request include:
- The "session.ts" uses a strategy method to figure out where to go next after login.  Passing an "undefined" is going to use the default strategy which goes to the base dashboard like it was originally.
- The "Login.tsx" now accepts a redirect url to move either go back or redirect to another page.  Passing "Back" will call back on the browser to go to the page it was before requiring login.