### PR TITLE
Making outputListItem and StackTraceListItem look the same

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "browser-sync": "^2.17.5",
     "bs-fullscreen-message": "^1.1.0",
     "chai": "^3.5.0",
+    "chai-enzyme": "^0.6.1",
     "connect-history-api-fallback": "^1.3.0",
     "coveralls": "^2.11.14",
     "css-loader": "^0.25.0",

--- a/src/components/OutputList/OutputListItem.test.tsx
+++ b/src/components/OutputList/OutputListItem.test.tsx
@@ -21,7 +21,13 @@ describe("OutputListItem", function () {
         });
 
         const wrapper = shallow(<OutputListItem output={output} />);
-        expect(wrapper.find("li")).to.have.length(1);
 
+        let item = wrapper.find("StackTraceTextItem");
+        expect(item).to.have.length(1);
+
+        expect(item.prop("id")).to.equal(output.id);
+        expect(item.prop("timestamp")).to.equal(output.timestamp);
+        expect(item.prop("message")).to.equal(output.message); // Message is the top and raw is the bottom so it's combined.
+        expect(item.prop("levelColor")).to.equal(output.levelColor);
     });
 });

--- a/src/components/OutputList/OutputListItem.tsx
+++ b/src/components/OutputList/OutputListItem.tsx
@@ -1,7 +1,8 @@
-import * as moment from "moment";
 import * as React from "react";
 
 import Output from "../../models/output";
+
+import StackTraceTextItem from "./StackTraceTextItem";
 
 interface OutputListItemProps {
     output: Output;
@@ -18,17 +19,12 @@ export default class OutputListItem extends React.Component<OutputListItemProps,
 
     render() {
         return (
-            <li key={this.props.output.id} style={this.style()}>
-                <span style={{color: "rgb(102, 217, 239)", paddingRight: "10px"}}>
-                    {moment(this.props.output.timestamp).format("hh:mm:ss.SSSSS")}
-                </span>
-                <span style={{ color: this.props.output.levelColor }}>
-                    {this.props.output.level}
-                </span>
-                <span style={{paddingLeft: "10px", color: "#EEEEEE"}}>
-                    {this.props.output.message}
-                </span>
-            </li>
+            <StackTraceTextItem
+                id={this.props.output.id}
+                timestamp={this.props.output.timestamp}
+                level={this.props.output.level}
+                levelColor={this.props.output.levelColor}
+                message={this.props.output.message} />
         );
     }
 }

--- a/src/components/OutputList/StackTraceListItem.test.tsx
+++ b/src/components/OutputList/StackTraceListItem.test.tsx
@@ -34,6 +34,12 @@ describe("StackTraceListItem", function () {
             <StackTraceListItem stackTrace={stackTrace} />
         ));
 
-        expect(wrapper.find("li")).to.have.length(1);
+        let item = wrapper.find("StackTraceTextItem");
+        expect(item).to.have.length(1);
+
+        expect(item.prop("id")).to.equal(stackTrace.id);
+        expect(item.prop("timestamp")).to.equal(stackTrace.timestamp);
+        expect(item.prop("message")).to.equal(stackTrace.message + stackTrace.raw); // Message is the top and raw is the bottom so it's combined.
+        expect(item.prop("levelColor")).to.equal("red");
     });
 });

--- a/src/components/OutputList/StackTraceListItem.tsx
+++ b/src/components/OutputList/StackTraceListItem.tsx
@@ -1,7 +1,8 @@
-import * as moment from "moment";
 import * as React from "react";
 
 import StackTrace from "../../models/stack-trace";
+
+import StackTraceTextItem from "./StackTraceTextItem";
 
 interface StackTraceListItemProps {
     stackTrace: StackTrace;
@@ -17,27 +18,15 @@ export default class StackTraceListItem extends React.Component<StackTraceListIt
     }
 
     render() {
-        let stackTraceElements: JSX.Element[] = [];
-
-        for (let stackTraceElement of this.props.stackTrace.elements) {
-            stackTraceElements.push(
-                <p style={{margin: "0px 0px 0px 5px", fontSize: "12px", lineHeight: "14px" }}>{stackTraceElement.raw}</p>
-            );
-        }
+        let fullTrace = this.props.stackTrace.message + this.props.stackTrace.raw;
 
         return (
-            <li key={this.props.stackTrace.id} style={this.style()}>
-                <span style={{color: "rgb(102, 217, 239)", paddingRight: "10px"}}>
-                    {moment(this.props.stackTrace.timestamp).format("hh:mm:ss.SSSSS")}
-                </span>
-                <span style={{ color: "red" }}>
-                    CRASH
-                </span>
-                <span style={{paddingLeft: "10px", color: "#EEEEEE"}}>
-                    {this.props.stackTrace.message}
-                </span>
-                {stackTraceElements}
-            </li>
+            <StackTraceTextItem
+                id={this.props.stackTrace.id}
+                timestamp={this.props.stackTrace.timestamp}
+                level={"CRASH"}
+                levelColor={"red"}
+                message={fullTrace} />
         );
     }
 }

--- a/src/components/OutputList/StackTraceTextItem.test.tsx
+++ b/src/components/OutputList/StackTraceTextItem.test.tsx
@@ -1,0 +1,78 @@
+import * as chai from "chai";
+import * as chaiEnzyme from "chai-enzyme";
+import { shallow } from "enzyme";
+import * as moment from "moment";
+import * as React from "react";
+
+import { DEFAULT_TIME_FORMAT, StackTraceTextItem } from "./StackTraceTextItem";
+
+chai.use(chaiEnzyme());
+let expect = chai.expect;
+
+const DEFAULT_PROPS = StackTraceTextItem.defaultProps;
+
+describe("StackTraceTextItem", function () {
+    it("renders default correctly", function () {
+        let date = new Date();
+        let dateString = moment(date).format(DEFAULT_TIME_FORMAT);
+
+        let wrapper = shallow((
+            <StackTraceTextItem
+                id="id"
+                message="Hello"
+                timestamp={date}
+                level="DEBUG"/>
+        ));
+
+        let listItem = wrapper.find("li");
+        expect(listItem).to.have.length(1);
+        // expect(listItem).to.have.attr("key", "id"); // This is actually for React. It gets removed. Would like a way to test it.
+
+        let spans = wrapper.find("span");
+        expect(spans).to.have.length(3);
+
+        let timeSpan = spans.at(0);
+        expect(timeSpan.text()).to.equal(dateString);
+
+        let levelSpan = spans.at(1);
+        expect(levelSpan.text()).to.equal("DEBUG");
+        expect(levelSpan).to.have.style("color", DEFAULT_PROPS.levelColor);
+
+        let messageSpan = spans.at(2);
+        expect(messageSpan.text()).to.equal("Hello");
+        expect(messageSpan).to.have.style("color", DEFAULT_PROPS.messageColor);
+    });
+
+    it("renders overridden correctly", function () {
+        let date = new Date();
+        let dateString = moment(date).format(DEFAULT_TIME_FORMAT);
+
+        let wrapper = shallow((
+            <StackTraceTextItem
+                id="id"
+                message="Hello"
+                timestamp={date}
+                levelColor="#FF0000"
+                messageColor="#FFFF00"
+                level="DEBUG"/>
+        ));
+
+        let listItem = wrapper.find("li");
+        expect(listItem).to.have.length(1);
+        // expect(listItem).to.have.attr("key", "id"); // This is actually for React. It gets removed. Would like a way to test it.
+
+        let spans = wrapper.find("span");
+        expect(spans).to.have.length(3);
+
+        let timeSpan = spans.at(0);
+        expect(timeSpan.text()).to.equal(dateString);
+
+        let levelSpan = spans.at(1);
+        expect(levelSpan.text()).to.equal("DEBUG");
+        expect(levelSpan).to.have.style("color", "#FF0000");
+
+        let messageSpan = spans.at(2);
+        expect(messageSpan.text()).to.equal("Hello");
+        expect(messageSpan).to.have.style("color", "#FFFF00");
+    });
+});

--- a/src/components/OutputList/StackTraceTextItem.tsx
+++ b/src/components/OutputList/StackTraceTextItem.tsx
@@ -1,0 +1,60 @@
+import * as moment from "moment";
+import * as React from "react";
+
+export interface StackTraceProps {
+    id: string;
+    timestamp: Date | moment.Moment;
+    level: string;
+    message: string;
+    levelColor?: string;
+    messageColor?: string;
+}
+
+export const DEFAULT_TIME_FORMAT = "hh:mm:ss.SSSSS";
+
+export class StackTraceTextItem extends React.Component<StackTraceProps, any> {
+
+    constructor(props: StackTraceProps) {
+        super(props);
+        this.state = {};
+    }
+
+    static defaultProps: StackTraceProps = {
+            id: "",
+            timestamp: undefined,
+            level: "",
+            message: "",
+            levelColor: "white",
+            messageColor: "#EEEEEE"
+    };
+
+    static style() {
+        return {
+            color: "white",
+            margin: "5px"
+        };
+    }
+
+    render() {
+        const { id, level, message, timestamp, levelColor, messageColor } = this.props;
+
+        let timestampMoment = moment(timestamp);
+        let formattedTime = timestampMoment.format(DEFAULT_TIME_FORMAT);
+
+        return (
+            <li key={id} style={StackTraceTextItem.style()}>
+                <span style={{ color: "rgb(102, 217, 239)", paddingRight: "10px" }}>
+                    {formattedTime}
+                </span>
+                <span style={{ color: levelColor }}>
+                    {level}
+                </span>
+                <span style={{ paddingLeft: "10px", color: messageColor }}>
+                    {message}
+                </span>
+            </li>
+        );
+    }
+}
+
+export default StackTraceTextItem;

--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,7 @@
 {
   "globalDependencies": {
     "chai": "registry:dt/chai#3.4.0+20160601211834",
+    "chai-enzyme": "registry:dt/chai-enzyme#0.5.0+20161121205806",
     "classnames": "registry:dt/classnames#0.0.0+20160316155526",
     "enzyme": "registry:dt/enzyme#2.4.1+20161004164857",
     "es6-promise": "registry:dt/es6-promise#0.0.0+20160614011821",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,3 +1,4 @@
+/// <reference path="globals/chai-enzyme/index.d.ts" />
 /// <reference path="globals/chai/index.d.ts" />
 /// <reference path="globals/classnames/index.d.ts" />
 /// <reference path="globals/enzyme/index.d.ts" />


### PR DESCRIPTION
Fixes #126 

Changes in this pull request include:
- OutputListItem and StackTraceListItem now use the same root elements.
- Now importing chai-enzyme which allows looking at attributes of raw HTML elements that aren't ReactComponents.