### PR TITLE
Logs swap

### DIFF
--- a/src/actions/session.test.ts
+++ b/src/actions/session.test.ts
@@ -147,7 +147,6 @@ describe("Session.ts", function () {
 
         before("Stubbing auth namespace.", function () {
             signUpWithEmail = sinon.stub(auth, "signUpWithEmail").returns(new Promise<any>((resolve, reject) => {
-                console.info("THROWING AN ERROR");
                 reject(new Error("Error failed do to requirements of the test."));
             }));
 
@@ -334,7 +333,6 @@ describe("Session.ts", function () {
         let initialState = {};
         let store = mockStore(initialState);
 
-        console.log(store);
         return loginAction(store.dispatch).then(function (user: User) {
             let numberOfActions = (redirectPath) ? 3 : 2;
             let actions = store.getActions() as any;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -67,10 +67,8 @@ export class LoginPage extends React.Component<LoginPageProps, LoginPageState> {
     }
 
     handleFormSubmit(email: string, pass: string) {
-        console.info("Logging in with " + email + " " + pass);
         this.props.login(email, pass)
             .catch((err: Error) => {
-                console.info("ERROR " + err.message);
                 this.state.error = err.message;
                 this.setState(this.state);
             });
@@ -79,7 +77,6 @@ export class LoginPage extends React.Component<LoginPageProps, LoginPageState> {
     handleFormLoginWithGithub() {
         this.props.loginWithGithub()
             .catch((err: Error) => {
-                console.info("ERROR " + err.message);
                 this.state.error = err.message;
                 this.setState(this.state);
             });
@@ -88,7 +85,6 @@ export class LoginPage extends React.Component<LoginPageProps, LoginPageState> {
     handleFormSignUpWithEmail(email: string, pass: string, confirmPass: string) {
         this.props.signUpWithEmail(email, pass, confirmPass)
             .catch((err: Error) => {
-                console.info("ERROR " + err.message);
                 this.state.error = err.message;
                 this.setState(this.state);
             });

--- a/src/pages/logspage/LogsExplorer/LogsExplorer.test.tsx
+++ b/src/pages/logspage/LogsExplorer/LogsExplorer.test.tsx
@@ -90,8 +90,8 @@ describe("LogExplorer", function () {
 
             it("clears conversation on new props.", function () {
                 wrapper.setProps({
-                    source: { source },
-                    logMap: { logMap }
+                    source: source,
+                    logMap: logMap
                 });
 
                 expect(wrapper.state("selectedConvo")).to.be.undefined;

--- a/src/pages/logspage/LogsExplorer/LogsExplorer.test.tsx
+++ b/src/pages/logspage/LogsExplorer/LogsExplorer.test.tsx
@@ -19,15 +19,19 @@ chai.use(sinonChai);
 let expect = chai.expect;
 
 describe("LogExplorer", function () {
+
     describe("without properties", function () {
         let wrapper = shallow(<LogsExplorer source={undefined} logMap={undefined} />);
+
         it("renders a FilterBar", function () {
             expect(wrapper.find("FilterBar")).to.have.length(1);
         });
+
         it("does not render an Interaction", function () {
             expect(wrapper.find("Interaction")).to.have.length(0);
         });
     });
+
     describe("with properties", function () {
         let logs: Log[] = dummyLogs(4);
         let outputs: Output[] = dummyOutputs(2);
@@ -41,11 +45,13 @@ describe("LogExplorer", function () {
         it("renders a FilterBar", function () {
             expect(wrapper.find("FilterBar")).to.have.length(1);
         });
+
         describe("without a conversation selected", function () {
             it("does not render an Interaction", function () {
                 expect(wrapper.find("Interaction")).to.have.length(0);
             });
         });
+
         describe("with a conversation selected", function () {
 
             // Set up some stubs
@@ -80,6 +86,15 @@ describe("LogExplorer", function () {
             it("sets the log outputs", function () {
                 expect(wrapper.state("selectedConvo").outputs[0]).to.equal(outputs[0]);
                 expect(wrapper.state("selectedConvo").outputs[1]).to.equal(outputs[1]);
+            });
+
+            it("clears conversation on new props.", function () {
+                wrapper.setProps({
+                    source: { source },
+                    logMap: { logMap }
+                });
+
+                expect(wrapper.state("selectedConvo")).to.be.undefined;
             });
         });
     });

--- a/src/pages/logspage/LogsExplorer/LogsExplorer.test.tsx
+++ b/src/pages/logspage/LogsExplorer/LogsExplorer.test.tsx
@@ -68,15 +68,18 @@ describe("LogExplorer", function () {
                 onResizeStub.restore();
                 sizeStub.restore();
             });
+
             it("sets the correct request", function () {
-                expect(wrapper.state().request).to.equal(logs[0]);
+                expect(wrapper.state("selectedConvo").request).to.equal(logs[0]);
             });
+
             it("sets the correct response", function () {
-                expect(wrapper.state().response).to.equal(logs[1]);
+                expect(wrapper.state("selectedConvo").response).to.equal(logs[1]);
             });
+
             it("sets the log outputs", function () {
-                expect(wrapper.state().outputs[0]).to.equal(outputs[0]);
-                expect(wrapper.state().outputs[1]).to.equal(outputs[1]);
+                expect(wrapper.state("selectedConvo").outputs[0]).to.equal(outputs[0]);
+                expect(wrapper.state("selectedConvo").outputs[1]).to.equal(outputs[1]);
             });
         });
     });

--- a/src/pages/logspage/LogsExplorer/LogsExplorer.tsx
+++ b/src/pages/logspage/LogsExplorer/LogsExplorer.tsx
@@ -8,9 +8,7 @@ import Conversation from "../../../models/conversation";
 import ConversationList from "../../../models/conversation-list";
 import Log from "../../../models/log";
 import LogQuery from "../../../models/log-query";
-import Output from "../../../models/output";
 import Source from "../../../models/source";
-import StackTrace from "../../../models/stack-trace";
 import { LogMap } from "../../../reducers/log";
 import browser from "../../../utils/browser";
 import { FilterableConversationList } from "../FilterableConversationList";
@@ -26,12 +24,9 @@ interface LogExplorerProps {
 }
 
 interface LogExplorerState {
-    request: Log | undefined;
-    response: Log | undefined;
-    outputs: Output[];
-    stackTraces: StackTrace[];
-    filter?: FilterType;
     filterBarHidden: boolean;
+    selectedConvo?: Conversation;
+    filter?: FilterType;
 }
 
 export default class LogExplorer extends React.Component<LogExplorerProps, LogExplorerState> {
@@ -39,29 +34,17 @@ export default class LogExplorer extends React.Component<LogExplorerProps, LogEx
     constructor(props: any) {
         super(props);
         this.state = {
-            request: undefined,
-            response: undefined,
-            outputs: [],
-            stackTraces: [],
             filterBarHidden: false
         };
     }
 
     componentWillReceiveProps?(nextProps: LogExplorerProps, nextContext: any): void {
-        this.state = {...this.state, ...{
-            request: undefined,
-            response: undefined,
-            outputs: [],
-            stackTraces: []
-        }};
+        this.state.selectedConvo = undefined;
         this.setState(this.state);
     }
 
     onConversationClicked(conversation: Conversation) {
-        this.state.request = conversation.request;
-        this.state.response = conversation.response;
-        this.state.outputs = conversation.outputs;
-        this.state.stackTraces = conversation.stackTraces;
+        this.state.selectedConvo = conversation;
         this.setState(this.state);
     }
 
@@ -106,13 +89,13 @@ export default class LogExplorer extends React.Component<LogExplorerProps, LogEx
                 onShowConversation={this.onConversationClicked.bind(this)} />
         );
 
-        let rightSide = this.state.request ?
+        let rightSide = this.state.selectedConvo ?
             (
                 <Interaction
-                    request={this.state.request}
-                    response={this.state.response}
-                    outputs={this.state.outputs}
-                    stackTraces={this.state.stackTraces} />
+                    request={this.state.selectedConvo.request}
+                    response={this.state.selectedConvo.response}
+                    outputs={this.state.selectedConvo.outputs}
+                    stackTraces={this.state.selectedConvo.stackTraces} />
             ) : (
                 <h6> Select a log to view </h6>
             );

--- a/src/pages/logspage/LogsExplorer/LogsExplorer.tsx
+++ b/src/pages/logspage/LogsExplorer/LogsExplorer.tsx
@@ -47,6 +47,16 @@ export default class LogExplorer extends React.Component<LogExplorerProps, LogEx
         };
     }
 
+    componentWillReceiveProps?(nextProps: LogExplorerProps, nextContext: any): void {
+        this.state = {...this.state, ...{
+            request: undefined,
+            response: undefined,
+            outputs: [],
+            stackTraces: []
+        }};
+        this.setState(this.state);
+    }
+
     onConversationClicked(conversation: Conversation) {
         this.state.request = conversation.request;
         this.state.response = conversation.response;

--- a/src/pages/logspage/LogsExplorer/LogsExplorer.tsx
+++ b/src/pages/logspage/LogsExplorer/LogsExplorer.tsx
@@ -77,8 +77,9 @@ export default class LogExplorer extends React.Component<LogExplorerProps, LogEx
         let logs: Log[];
 
         if (this.props.source) {
-            query = this.props.logMap[this.props.source.id].query;
-            logs = this.props.logMap[this.props.source.id].logs;
+            let logMap = this.props.logMap[this.props.source.id];
+            query = logMap.query;
+            logs = logMap.logs;
         }
 
         let leftSide = (


### PR DESCRIPTION
Fixes #130

Changes in this pull request include:
- LogsExplorer properly clears out the selected conversation when new props comes in (meaning a swap).
