### PR TITLE
Date query

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "browser-sync": "^2.17.5",
     "bs-fullscreen-message": "^1.1.0",
     "chai": "^3.5.0",
+    "chai-datetime": "^1.4.1",
     "chai-enzyme": "^0.6.1",
     "connect-history-api-fallback": "^1.3.0",
     "coveralls": "^2.11.14",

--- a/src/actions/log.test.ts
+++ b/src/actions/log.test.ts
@@ -49,28 +49,72 @@ describe("Log Actions", function () {
             });
         });
 
-        it("Sets the appropriate default query", function () {
-            let initialState = {};
-            let store = mockStore(initialState);
-            let source = new Source({
-                name: "Test"
+        describe("Query tests", function () {
+
+            let initialState: any;
+            let store: any;
+            let source: Source;
+
+            before(function () {
+                source = new Source({
+                    name: "Test"
+                });
             });
 
-            let sevenDaysAgo: Date = new Date();
-            sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+            beforeEach(function () {
+                initialState = {};
+                store = mockStore(initialState);
+            });
 
-            return store.dispatch(log.getLogs(source)).then(function () {
+            it("Sets the appropriate source for the query.", function () {
+                return store.dispatch(log.getLogs(source)).then(function() {
+                    let actions: any[] = store.getActions();
 
-                let actions: any[] = store.getActions();
+                    let setLogAction: log.SetLogsAction = actions[1] as log.SetLogsAction;
+                    let query = setLogAction.query;
+                    expect(query).to.not.be.undefined;
+                    expect(query.source).to.equal(source);
+                });
+            });
 
-                let setLogAction: log.SetLogsAction = actions[1] as log.SetLogsAction;
+            it("Sets the appropriate default date query", function () {
+                let sevenDaysAgo: Date = new Date();
+                sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
 
-                let query = setLogAction.query;
+                return store.dispatch(log.getLogs(source)).then(function () {
 
-                expect(query).to.not.be.undefined;
-                expect(query.source).to.equal(source);
-                expect(query.startTime).to.not.be.undefined;
-                expect(query.startTime).to.equalDate(sevenDaysAgo);
+                    let actions: any[] = store.getActions();
+
+                    let setLogAction: log.SetLogsAction = actions[1] as log.SetLogsAction;
+
+                    let query = setLogAction.query;
+
+                    expect(query).to.not.be.undefined;
+                    expect(query.startTime).to.not.be.undefined;
+                    expect(query.startTime).to.equalDate(sevenDaysAgo);
+                    expect(query.endTime).to.equalDate(new Date());
+                });
+            });
+
+            it("Sets the appropriate overridden date query.", function () {
+                let startDate = new Date();
+                startDate.setDate(startDate.getDay() - 8);
+
+                let endDate = new Date();
+
+                return store.dispatch(log.getLogs(source, startDate, endDate)).then(function () {
+                    let actions: any[] = store.getActions();
+
+                    let setLogAction: log.SetLogsAction = actions[1] as log.SetLogsAction;
+
+                    let query = setLogAction.query;
+
+                    expect(query).to.not.be.undefined;
+                    expect(query.startTime).to.not.be.undefined;
+                    expect(query.startTime).to.equalDate(startDate);
+                    expect(query.endTime).to.not.be.undefined;
+                    expect(query.endTime).to.equalDate(endDate);
+                });
             });
         });
     });

--- a/src/actions/log.test.ts
+++ b/src/actions/log.test.ts
@@ -12,6 +12,7 @@ import Source from "../models/source";
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 
+chai.use(require("chai-datetime"));
 let expect = chai.expect;
 
 describe("Log Actions", function () {
@@ -28,6 +29,7 @@ describe("Log Actions", function () {
         afterEach(function () {
             fetchMock.restore();
         });
+
         it("retrieves the logs", function (done) {
 
             let initialState = {};
@@ -44,6 +46,31 @@ describe("Log Actions", function () {
                 expect(actions[0].type).to.equal(FETCH_LOGS_REQUEST);
                 expect(actions[1].type).to.equal(SET_LOGS);
                 done();
+            });
+        });
+
+        it("Sets the appropriate default query", function () {
+            let initialState = {};
+            let store = mockStore(initialState);
+            let source = new Source({
+                name: "Test"
+            });
+
+            let sevenDaysAgo: Date = new Date();
+            sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+            return store.dispatch(log.getLogs(source)).then(function () {
+
+                let actions: any[] = store.getActions();
+
+                let setLogAction: log.SetLogsAction = actions[1] as log.SetLogsAction;
+
+                let query = setLogAction.query;
+
+                expect(query).to.not.be.undefined;
+                expect(query.source).to.equal(source);
+                expect(query.startTime).to.not.be.undefined;
+                expect(query.startTime).to.equalDate(sevenDaysAgo);
             });
         });
     });

--- a/src/actions/log.ts
+++ b/src/actions/log.ts
@@ -35,19 +35,23 @@ export function fetchLogsRequest() {
     };
 }
 
-export function getLogs(source: Source) {
+export function getLogs(source: Source, startTime?: Date, endTime?: Date) {
     return function (dispatch: Redux.Dispatch<any>) {
 
         dispatch(fetchLogsRequest());
 
-        // Right now we are only looking for the last seven days
-        let startTime: Date = new Date();
-        startTime.setDate(startTime.getDate() - 7);
+        if (!startTime) {
+            // Right now we are only looking for the last seven days
+            startTime = new Date();
+            startTime.setDate(startTime.getDate() - 7);
+        }
 
         let query: LogQuery = new LogQuery({
             source: source,
-            startTime: startTime
+            startTime: startTime,
+            endTime: endTime
         });
+
         return service.getLogs(query).then(function (logs) {
             dispatch(setLogs(query, logs));
         });

--- a/src/pages/logspage/FilterBar/FilterBar.test.tsx
+++ b/src/pages/logspage/FilterBar/FilterBar.test.tsx
@@ -1,0 +1,31 @@
+import * as chai from "chai";
+import { shallow } from "enzyme";
+import * as React from "react";
+import * as sinon from "sinon";
+import * as sinonChai from "sinon-chai";
+
+import  Filterbar from "./FilterBar";
+
+import Source from "../../../models/source";
+
+import LogQuery from "../../../models/log-query";
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe("Filter Bar", function() {
+
+    it ("Renders correctly", function() {
+        let source = new Source({
+            name: "TestSource"
+        });
+        let onFilter = sinon.spy();
+        let logQuery = new LogQuery({ source: source});
+
+        let wrapper = shallow(<Filterbar onFilter={onFilter}  query={logQuery} />);
+
+        console.log(wrapper);
+        expect(wrapper.find("ThemedDropdown")).to.have.length(1); // Filter by type.
+        expect(wrapper.find("ThemedDatePicker")).to.have.length(2); // filter by date range
+    });
+});

--- a/src/pages/logspage/FilterBar/FilterBar.test.tsx
+++ b/src/pages/logspage/FilterBar/FilterBar.test.tsx
@@ -148,7 +148,7 @@ describe("Filter Bar", function () {
 
                 startDatePicker.simulate("change", date);
 
-                date.setHours(0, 0, 0);
+                date.setHours(0, 0, 0, 0);
 
                 expect(wrapper.state("startDate")).to.equalDate(date);
                 expect(wrapper.state("startDate")).to.equalTime(date);
@@ -171,7 +171,7 @@ describe("Filter Bar", function () {
 
                 endDatePicker.simulate("change", date);
 
-                date.setHours(59, 59, 59);
+                date.setHours(23, 59, 59, 999);
 
                 expect(wrapper.state("endDate")).to.equalDate(date);
                 expect(wrapper.state("endDate")).to.equalTime(date);

--- a/src/pages/logspage/FilterBar/FilterBar.test.tsx
+++ b/src/pages/logspage/FilterBar/FilterBar.test.tsx
@@ -1,10 +1,13 @@
 import * as chai from "chai";
-import { shallow } from "enzyme";
+import { shallow, ShallowWrapper } from "enzyme";
 import * as React from "react";
 import * as sinon from "sinon";
 import * as sinonChai from "sinon-chai";
 
-import  Filterbar from "./FilterBar";
+import DatePicker from "react-toolbox/lib/date_picker";
+import Dropdown from "react-toolbox/lib/dropdown";
+
+import Filterbar, { FilterProps, FilterState } from "./FilterBar";
 
 import Source from "../../../models/source";
 
@@ -13,19 +16,75 @@ import LogQuery from "../../../models/log-query";
 chai.use(sinonChai);
 const expect = chai.expect;
 
-describe("Filter Bar", function() {
+describe("Filter Bar", function () {
 
-    it ("Renders correctly", function() {
+    it("Renders correctly", function () {
         let source = new Source({
             name: "TestSource"
         });
         let onFilter = sinon.spy();
-        let logQuery = new LogQuery({ source: source});
+        let logQuery = new LogQuery({ source: source });
 
-        let wrapper = shallow(<Filterbar onFilter={onFilter}  query={logQuery} />);
+        let wrapper = shallow(<Filterbar onFilter={onFilter} query={logQuery} />);
 
-        console.log(wrapper);
-        expect(wrapper.find("ThemedDropdown")).to.have.length(1); // Filter by type.
-        expect(wrapper.find("ThemedDatePicker")).to.have.length(2); // filter by date range
+        expect(wrapper.find(Dropdown)).to.have.length(1); // Filter by type.
+        expect(wrapper.find(DatePicker)).to.have.length(2); // filter by date range
+    });
+
+    it("Gives the appropriate props to the dropdown component.", function () {
+        let source = new Source({
+            name: "TestSource"
+        });
+        let onFilter = sinon.spy();
+        let logQuery = new LogQuery({ source: source });
+
+        let wrapper = shallow(<Filterbar onFilter={onFilter} query={logQuery} />);
+
+        const dropdown = wrapper.find("ThemedDropdown");
+        expect(dropdown.prop("label")).to.equal("Log Level");
+        expect(dropdown.prop("onChange")).to.not.be.undefined;
+
+        const logtypes = wrapper.state("logTypes");
+
+        expect(dropdown.prop("source")).to.equal(logtypes);
+        expect(dropdown.prop("value")).to.equal(logtypes[0].value);
+    });
+
+    describe("Filters", function () {
+
+        let source: Source;
+        let onFilter: Sinon.SinonSpy;
+        let logQuery: LogQuery;
+        let wrapper: ShallowWrapper<FilterProps, FilterState>;
+
+        before(function () {
+            source = new Source({
+                name: "TestSource"
+            });
+            onFilter = sinon.spy();
+            logQuery = new LogQuery({ source: source });
+        });
+
+        beforeEach(function () {
+            onFilter.reset();
+            wrapper = shallow(<Filterbar onFilter={onFilter} query={logQuery} />) as ShallowWrapper<FilterProps, FilterState>;
+        });
+
+        describe("Type Filters", function () {
+
+            let dropdown: ShallowWrapper<any, any>;
+            let logTypes: any;
+
+            beforeEach(function () {
+                dropdown = wrapper.find(Dropdown);
+                logTypes = wrapper.state("logTypes");
+            });
+
+            it("Tests the state after a type filter change.", function () {
+                dropdown.simulate("change", "DEBUG");
+
+                expect(wrapper.state("selectedType")).to.equal("DEBUG");
+            });
+        });
     });
 });

--- a/src/pages/logspage/FilterBar/FilterBar.test.tsx
+++ b/src/pages/logspage/FilterBar/FilterBar.test.tsx
@@ -14,6 +14,7 @@ import Source from "../../../models/source";
 import LogQuery from "../../../models/log-query";
 
 chai.use(sinonChai);
+chai.use(require("chai-datetime"));
 const expect = chai.expect;
 
 describe("Filter Bar", function () {
@@ -40,7 +41,7 @@ describe("Filter Bar", function () {
 
         let wrapper = shallow(<Filterbar onFilter={onFilter} query={logQuery} />);
 
-        const dropdown = wrapper.find("ThemedDropdown");
+        const dropdown = wrapper.find(Dropdown);
         expect(dropdown.prop("label")).to.equal("Log Level");
         expect(dropdown.prop("onChange")).to.not.be.undefined;
 
@@ -48,6 +49,44 @@ describe("Filter Bar", function () {
 
         expect(dropdown.prop("source")).to.equal(logtypes);
         expect(dropdown.prop("value")).to.equal(logtypes[0].value);
+    });
+
+    it("Gives the appropriate props to the start date picker.", function () {
+        let source = new Source({
+            name: "TestSource"
+        });
+        let onFilter = sinon.spy();
+        let logQuery = new LogQuery({ source: source });
+
+        let wrapper = shallow(<Filterbar onFilter={onFilter} query={logQuery} />);
+
+        const startDatePicker = wrapper.find(DatePicker).at(0);
+
+        expect(startDatePicker.prop("label")).to.equal("Start Date");
+        expect(startDatePicker.prop("minDate")).to.be.undefined;
+        expect(startDatePicker.prop("maxDate")).to.equalDate(new Date());
+        expect(startDatePicker.prop("value")).to.equal(wrapper.state("startDate"));
+        expect(startDatePicker.prop("onChange")).to.not.be.undefined;
+        expect(startDatePicker.prop("readonly")).to.equal(false);
+    });
+
+    it("Gives the appropriate props to the end date picker.", function () {
+        let source = new Source({
+            name: "TestSource"
+        });
+        let onFilter = sinon.spy();
+        let logQuery = new LogQuery({ source: source });
+
+        let wrapper = shallow(<Filterbar onFilter={onFilter} query={logQuery} />);
+
+        const endDatePicker = wrapper.find(DatePicker).at(1);
+
+        expect(endDatePicker.prop("label")).to.equal("End Date");
+        expect(endDatePicker.prop("minDate")).to.equal(wrapper.state("startDate"));
+        expect(endDatePicker.prop("maxDate")).to.equalDate(new Date());
+        expect(endDatePicker.prop("value")).to.be.equal(wrapper.state("endDate"));
+        expect(endDatePicker.prop("onChange")).to.not.be.undefined;
+        expect(endDatePicker.prop("readonly")).to.equal(false);
     });
 
     describe("Filters", function () {
@@ -84,6 +123,69 @@ describe("Filter Bar", function () {
                 dropdown.simulate("change", "DEBUG");
 
                 expect(wrapper.state("selectedType")).to.equal("DEBUG");
+            });
+
+            it("Tests the callback is called on type filter change.", function () {
+                dropdown.simulate("change", "DEBUG");
+
+                expect(onFilter).to.have.been.calledOnce;
+            });
+        });
+
+        describe("Date Filters", function () {
+            let startDatePicker: ShallowWrapper<any, any>;
+            let endDatePicker: ShallowWrapper<any, any>;
+
+            beforeEach(function () {
+                const pickers = wrapper.find(DatePicker);
+                startDatePicker = pickers.at(0);
+                endDatePicker = pickers.at(1);
+            });
+
+            it("Tests state changes when start date picker is chosen.", function () {
+                let date = new Date();
+                date.setDate(date.getDate() - 3);
+
+                startDatePicker.simulate("change", date);
+
+                date.setHours(0, 0, 0);
+
+                expect(wrapper.state("startDate")).to.equalDate(date);
+                expect(wrapper.state("startDate")).to.equalTime(date);
+            });
+
+            it("Tests the maximum date of the start date picker is set to the end date when picked.", function () {
+                let date = new Date();
+                date.setDate(date.getDate() - 3);
+
+                endDatePicker.simulate("change", date);
+
+                startDatePicker = wrapper.find(DatePicker).at(0); // It re-renders so need the new one.
+
+                expect(startDatePicker.prop("maxDate")).to.equalDate(date);
+            });
+
+            it("Tests state changes when end date picker is chosen.", function () {
+                let date = new Date();
+                date.setDate(date.getDate() - 3);
+
+                endDatePicker.simulate("change", date);
+
+                date.setHours(59, 59, 59);
+
+                expect(wrapper.state("endDate")).to.equalDate(date);
+                expect(wrapper.state("endDate")).to.equalTime(date);
+            });
+
+            it("Tests the minimum date of the end date picker is set to the start date when picked.", function () {
+                let date = new Date();
+                date.setDate(date.getDate() - 3);
+
+                startDatePicker.simulate("change", date);
+
+                endDatePicker = wrapper.find(DatePicker).at(1); // It re-renders so need the new one.
+
+                expect(endDatePicker.prop("minDate")).to.equalDate(date);
             });
         });
     });

--- a/src/pages/logspage/FilterBar/FilterBar.tsx
+++ b/src/pages/logspage/FilterBar/FilterBar.tsx
@@ -17,18 +17,18 @@ export interface FilterProps {
     className?: string;
 }
 
-interface LogType {
-    value: string;
-    label: string;
-}
-
-interface FilterState {
+export interface FilterState {
     startDate?: Date;
     endDate?: Date;
     logTypes?: LogType[];
     selectedType?: string;
     filterMap: any;
     filterbarHidden: boolean;
+}
+
+interface LogType {
+    value: string;
+    label: string;
 }
 
 class FilterBar extends React.Component<FilterProps, FilterState> {
@@ -90,6 +90,7 @@ class FilterBar extends React.Component<FilterProps, FilterState> {
     }
 
     handleLogTypeChange(value: string) {
+        console.info("HANDLE LOG TYPE " + value);
         this.state.selectedType = value;
         this.setState(this.state);
         this.newFilter(new LogLevelFilter(value));
@@ -108,6 +109,7 @@ class FilterBar extends React.Component<FilterProps, FilterState> {
         let startHandleChange = this.handleDateChange.bind(this, "startDate");
         let endHandleChange = this.handleDateChange.bind(this, "endDate");
 
+        console.log(this.state);
         return (
             <Grid className={this.gridClasses()} >
                 <Cell col={2} tablet={2} phone={4}>

--- a/src/pages/logspage/FilterBar/FilterBar.tsx
+++ b/src/pages/logspage/FilterBar/FilterBar.tsx
@@ -1,5 +1,4 @@
 import * as classNames from "classnames";
-import * as moment from "moment";
 import * as React from "react";
 import DatePicker from "react-toolbox/lib/date_picker";
 import Dropdown from "react-toolbox/lib/dropdown";
@@ -104,7 +103,7 @@ class FilterBar extends React.Component<FilterProps, FilterState> {
     }
 
     render(): JSX.Element {
-        let queryStartDate = this.props.query ? moment(this.props.query.startTime).subtract(1, "days").toDate() : new Date();
+        // let queryStartDate = this.props.query ? moment(this.props.query.startTime).subtract(1, "days").toDate() : new Date();
         let queryEndDate = this.props.query ? this.props.query.endTime : new Date();
         let startHandleChange = this.handleDateChange.bind(this, "startDate");
         let endHandleChange = this.handleDateChange.bind(this, "endDate");
@@ -125,7 +124,6 @@ class FilterBar extends React.Component<FilterProps, FilterState> {
                     <DatePicker
                         theme={DatePickerFilterbarTheme}
                         label="Start Date"
-                        minDate={queryStartDate}
                         maxDate={this.state.endDate}
                         value={this.state.startDate}
                         onChange={startHandleChange}

--- a/src/pages/logspage/FilterBar/FilterBar.tsx
+++ b/src/pages/logspage/FilterBar/FilterBar.tsx
@@ -33,6 +33,9 @@ interface LogType {
 
 class FilterBar extends React.Component<FilterProps, FilterState> {
 
+    handleStartDateChange: Function;
+    handleEndDateChange: Function;
+
     constructor(props: FilterProps) {
         super(props);
 
@@ -51,6 +54,10 @@ class FilterBar extends React.Component<FilterProps, FilterState> {
             startDate: props.query ? props.query.startTime : undefined,
             endDate: props.query ? props.query.endTime : undefined
         };
+
+        this.handleStartDateChange = this.handleDateChange.bind(this, "startDate");
+        this.handleEndDateChange = this.handleDateChange.bind(this, "endDate");
+        this.handleLogTypeChange = this.handleLogTypeChange.bind(this);
     }
 
     gridClasses() {
@@ -105,8 +112,6 @@ class FilterBar extends React.Component<FilterProps, FilterState> {
     render(): JSX.Element {
         let fullEndDate = new Date();
         let queryEndDate = this.state.endDate ? this.state.endDate : fullEndDate;
-        let startHandleChange = this.handleDateChange.bind(this, "startDate");
-        let endHandleChange = this.handleDateChange.bind(this, "endDate");
 
         return (
             <Grid className={this.gridClasses()} >
@@ -115,7 +120,7 @@ class FilterBar extends React.Component<FilterProps, FilterState> {
                         theme={DropdownFilterbarTheme}
                         label="Log Level"
                         auto={false}
-                        onChange={this.handleLogTypeChange.bind(this)}
+                        onChange={this.handleLogTypeChange}
                         source={this.state.logTypes}
                         value={this.state.selectedType}
                         />
@@ -126,7 +131,7 @@ class FilterBar extends React.Component<FilterProps, FilterState> {
                         label="Start Date"
                         maxDate={queryEndDate}
                         value={this.state.startDate}
-                        onChange={startHandleChange}
+                        onChange={this.handleStartDateChange}
                         readonly={this.props.query ? false : true} />
                 </Cell>
                 <p style={{ color: "rgb(255, 255, 255)", fontSize: "26px", margin: "auto -5px", marginTop: "28px", display: "inline-block" }}>-</p>
@@ -137,7 +142,7 @@ class FilterBar extends React.Component<FilterProps, FilterState> {
                         minDate={this.state.startDate}
                         maxDate={fullEndDate}
                         value={this.state.endDate}
-                        onChange={endHandleChange}
+                        onChange={this.handleEndDateChange}
                         readonly={this.props.query ? false : true} />
                 </Cell>
             </Grid>

--- a/src/pages/logspage/FilterBar/FilterBar.tsx
+++ b/src/pages/logspage/FilterBar/FilterBar.tsx
@@ -103,7 +103,8 @@ class FilterBar extends React.Component<FilterProps, FilterState> {
     }
 
     render(): JSX.Element {
-        let queryEndDate = this.props.query ? this.props.query.endTime : new Date();
+        let fullEndDate = new Date();
+        let queryEndDate = this.props.query ? this.props.query.endTime : fullEndDate;
         let startHandleChange = this.handleDateChange.bind(this, "startDate");
         let endHandleChange = this.handleDateChange.bind(this, "endDate");
 
@@ -123,7 +124,7 @@ class FilterBar extends React.Component<FilterProps, FilterState> {
                     <DatePicker
                         theme={DatePickerFilterbarTheme}
                         label="Start Date"
-                        maxDate={this.state.endDate}
+                        maxDate={queryEndDate}
                         value={this.state.startDate}
                         onChange={startHandleChange}
                         readonly={this.props.query ? false : true} />
@@ -134,7 +135,7 @@ class FilterBar extends React.Component<FilterProps, FilterState> {
                         theme={DatePickerFilterbarTheme}
                         label="End Date"
                         minDate={this.state.startDate}
-                        maxDate={queryEndDate}
+                        maxDate={fullEndDate}
                         value={this.state.endDate}
                         onChange={endHandleChange}
                         readonly={this.props.query ? false : true} />

--- a/src/pages/logspage/FilterBar/FilterBar.tsx
+++ b/src/pages/logspage/FilterBar/FilterBar.tsx
@@ -103,7 +103,6 @@ class FilterBar extends React.Component<FilterProps, FilterState> {
     }
 
     render(): JSX.Element {
-        // let queryStartDate = this.props.query ? moment(this.props.query.startTime).subtract(1, "days").toDate() : new Date();
         let queryEndDate = this.props.query ? this.props.query.endTime : new Date();
         let startHandleChange = this.handleDateChange.bind(this, "startDate");
         let endHandleChange = this.handleDateChange.bind(this, "endDate");

--- a/src/pages/logspage/FilterBar/FilterBar.tsx
+++ b/src/pages/logspage/FilterBar/FilterBar.tsx
@@ -58,24 +58,24 @@ class FilterBar extends React.Component<FilterProps, FilterState> {
     }
 
     componentWillReceiveProps(nextProps: FilterProps) {
-        // The first time we get the query,
-        // we set it as the initial start and end dates.
+        // currently not letting the caller override state if it changed.
+        // TODO: It would be preferable to allow this or get rid of query.
         if (!this.state.endDate && nextProps.query) {
             this.setDateRange(nextProps.query.startTime, nextProps.query.endTime);
         }
     }
 
     setDateRange(startDate: Date, endDate: Date) {
-        if (startDate && endDate) {
-            // Right now these don't allow time so going to assume the beginning and the end of whatever day it's at.
-            this.state.startDate = startDate;
+        this.state.startDate = (startDate) ? new Date(startDate) : undefined;
+        if (this.state.startDate) {
             this.state.startDate.setHours(0, 0, 0, 0);
-
-            this.state.endDate = endDate;
-            this.state.endDate.setHours(23, 59, 59, 999);
-
-            this.setState(this.state);
         }
+
+        this.state.endDate = (endDate) ? new Date(endDate) : undefined;
+        if (this.state.endDate) {
+            this.state.endDate.setHours(23, 59, 59, 999);
+        }
+        this.setState(this.state);
     }
 
     handleDateChange(item: "startDate" | "endDate", value: Date) {
@@ -90,7 +90,6 @@ class FilterBar extends React.Component<FilterProps, FilterState> {
     }
 
     handleLogTypeChange(value: string) {
-        console.info("HANDLE LOG TYPE " + value);
         this.state.selectedType = value;
         this.setState(this.state);
         this.newFilter(new LogLevelFilter(value));

--- a/src/pages/logspage/FilterBar/FilterBar.tsx
+++ b/src/pages/logspage/FilterBar/FilterBar.tsx
@@ -14,7 +14,7 @@ const DropdownFilterbarTheme = require("../../../themes/dropdown-filterbar.scss"
 
 export interface FilterProps {
     query: LogQuery;
-    onFilter: (filter: FilterType) => void;
+    onFilter: (filter: CompositeFilter) => void;
     className?: string;
 }
 

--- a/src/pages/logspage/FilterBar/FilterBar.tsx
+++ b/src/pages/logspage/FilterBar/FilterBar.tsx
@@ -105,11 +105,10 @@ class FilterBar extends React.Component<FilterProps, FilterState> {
 
     render(): JSX.Element {
         let fullEndDate = new Date();
-        let queryEndDate = this.props.query ? this.props.query.endTime : fullEndDate;
+        let queryEndDate = this.state.endDate ? this.state.endDate : fullEndDate;
         let startHandleChange = this.handleDateChange.bind(this, "startDate");
         let endHandleChange = this.handleDateChange.bind(this, "endDate");
 
-        console.log(this.state);
         return (
             <Grid className={this.gridClasses()} >
                 <Cell col={2} tablet={2} phone={4}>

--- a/src/pages/logspage/Filters.test.tsx
+++ b/src/pages/logspage/Filters.test.tsx
@@ -1,9 +1,12 @@
-import { expect } from "chai";
+import * as chai from "chai";
 
 import Conversation from "../../models/conversation";
 import { Log, LogProperties } from "../../models/log";
 import { dummyOutputs } from "../../utils/test";
 import * as Filters from "./Filters";
+
+chai.use(require("chai-datetime"));
+let expect = chai.expect;
 
 let requestProps: LogProperties = {
     payload: "Request Payload!",
@@ -88,6 +91,14 @@ describe("Filters.tsx", function() {
             });
 
             expect(filter.filter(convo)).to.be.false;
+        });
+
+        it ("Tests it returns the appropriate filter from getFilter by type.", function() {
+            let success = new SuccessFilter();
+            let fail = new FailFilter();
+            let filter = new Filters.CompositeFilter([success, fail]);
+            expect(filter.getFilter(success.type).type).to.equal(success.type);
+            expect(filter.getFilter(fail.type).type).to.equal(fail.type);
         });
     });
 
@@ -236,6 +247,18 @@ describe("Filters.tsx", function() {
             let filter = new Filters.DateFilter(new Date());
             expect(filter.filter).to.not.be.undefined;
             expect(filter.filter).to.not.be.null;
+        });
+
+        it ("Tests the getStartDate property returns the appropriate value.", function() {
+            let startDate = new Date(2016, 12, 14);
+            let filter = new Filters.DateFilter(startDate, new Date(2016, 12, 16));
+            expect(filter.startDate).to.equalDate(startDate);
+        });
+
+        it ("Tests the getEndDate property returns the appropriate value.", function() {
+            let endDate = new Date(2016, 12, 16);
+            let filter = new Filters.DateFilter(new Date(2016, 12, 14), endDate);
+            expect(filter.endDate).to.equalDate(endDate);
         });
 
         it("Tests the filter will return true if between the start and end date.", function() {

--- a/src/pages/logspage/Filters.tsx
+++ b/src/pages/logspage/Filters.tsx
@@ -3,6 +3,8 @@ import * as moment from "moment";
 import Conversation from "../../models/conversation";
 import StringUtils from "../../utils/string";
 
+export const TYPE_DATE: string = "Date";
+
 export interface FilterType {
     type: string;
     filter: (item: Conversation) => boolean;
@@ -13,6 +15,15 @@ export class CompositeFilter implements FilterType {
 
     constructor(filters: FilterType[]) {
         this.filters = filters;
+    }
+
+    getFilter(type: string): FilterType | undefined {
+        for (let filterType of this.filters) {
+            if (filterType.type === type) {
+                return filterType;
+            }
+        }
+        return undefined;
     }
 
     get type(): string {
@@ -75,26 +86,34 @@ export class IDFilter implements FilterType {
 }
 
 export class DateFilter implements FilterType {
-    startDate: moment.Moment;
-    endDate: moment.Moment;
+    startMoment: moment.Moment;
+    endMoment: moment.Moment;
 
     constructor(startDate?: Date, endDate?: Date) {
-        this.startDate = (startDate) ? moment(startDate) : undefined;
-        this.endDate = (endDate) ? moment(endDate) : undefined;
+        this.startMoment = (startDate) ? moment(startDate) : undefined;
+        this.endMoment = (endDate) ? moment(endDate) : undefined;
     }
 
     get type(): string {
-        return "Date";
+        return TYPE_DATE;
+    }
+
+    get startDate(): Date {
+        return this.startMoment.toDate();
+    }
+
+    get endDate(): Date {
+        return this.endMoment.toDate();
     }
 
     get filter(): (item: Conversation) => boolean {
-        let startDate = this.startDate;
-        let endDate = this.endDate;
+        let startMoment = this.startMoment;
+        let endMoment = this.endMoment;
         return function (item: Conversation): boolean {
             if (item) {
                 let created = moment(item.timestamp);
-                let afterStart = startDate === undefined || created.isSameOrAfter(startDate);
-                let beforeEnd = endDate === undefined || created.isSameOrBefore(endDate);
+                let afterStart = startMoment === undefined || created.isSameOrAfter(startMoment);
+                let beforeEnd = endMoment === undefined || created.isSameOrBefore(endMoment);
                 return afterStart && beforeEnd;
             }
             return false;

--- a/src/pages/logspage/LogsExplorer/LogsExplorer.tsx
+++ b/src/pages/logspage/LogsExplorer/LogsExplorer.tsx
@@ -13,13 +13,14 @@ import { LogMap } from "../../../reducers/log";
 import browser from "../../../utils/browser";
 import { FilterableConversationList } from "../FilterableConversationList";
 import { FilterBar } from "../FilterBar";
-import { FilterType } from "../Filters";
+import { CompositeFilter, FilterType } from "../Filters";
 
 const style = require("./style.scss");
 
 interface LogExplorerProps {
     logMap: LogMap;
     source: Source;
+    onFilter?: (filter: CompositeFilter) => void;
     lockFilterBar?: boolean;
 }
 
@@ -55,7 +56,10 @@ export default class LogExplorer extends React.Component<LogExplorerProps, LogEx
         }
     }
 
-    handleFilter(filter: FilterType) {
+    handleFilter(filter: CompositeFilter) {
+        if (this.props.onFilter) {
+            this.props.onFilter(filter);
+        }
         this.state.filter = filter;
         this.setState(this.state);
     }

--- a/src/pages/logspage/LogsPage.test.tsx
+++ b/src/pages/logspage/LogsPage.test.tsx
@@ -1,15 +1,21 @@
 import * as chai from "chai";
 import { shallow } from "enzyme";
 import * as React from "react";
+import * as Sinon from "sinon";
 
 import LogsExplorer from "./LogsExplorer";
 import { LogsPage } from "./LogsPage";
 
+import { dummyLogs } from "../../utils/test";
+
 let expect = chai.expect;
 
 describe("LogsPage", function () {
-    let wrapper = shallow(<LogsPage source={undefined} logMap={undefined} />);
+
     it("renders a LogsExplorer", function() {
+        const getLogs = Sinon.stub().returns(dummyLogs(4));
+
+        let wrapper = shallow(<LogsPage source={undefined} logMap={undefined} getLogs={getLogs} />);
         expect(wrapper.find(LogsExplorer)).to.have.length(1);
     });
 });

--- a/src/pages/logspage/LogsPage.tsx
+++ b/src/pages/logspage/LogsPage.tsx
@@ -9,11 +9,12 @@ import { LogMap } from "../../reducers/log";
 import { CompositeFilter, DateFilter, TYPE_DATE } from "./Filters";
 import LogsExplorer from "./LogsExplorer";
 
-import LogService from "../../services/log";
+import { retrieveLogs } from "../../actions/log";
 
 export interface LogsPageProps {
     logMap: LogMap;
     source: Source;
+    getLogs: (query: LogQuery) => Promise<Log[]>;
 }
 
 interface LogsPageState {
@@ -25,6 +26,15 @@ function mapStateToProps(state: State.All) {
     return {
         logMap: state.log.logMap,
         source: state.source.currentSource
+    };
+}
+
+function mapDispatchToProps(dispatch: Redux.Dispatch<any>) {
+    return {
+        getLogs: function(query: LogQuery) {
+            const fetchLogs = retrieveLogs(query);
+            return fetchLogs(dispatch);
+        }
     };
 }
 
@@ -52,17 +62,8 @@ export class LogsPage extends React.Component<LogsPageProps, LogsPageState> {
                 startTime: dateFilter.startDate,
                 endTime: dateFilter.endDate
             });
-            const sourceId = this.state.source.id;
 
-            LogService.getLogs(query).then((value: Log[]) => {
-                this.state.logMap = {
-                    [sourceId]: {
-                        logs: value,
-                        query: query
-                    }
-                };
-                this.setState(this.state);
-            });
+            this.props.getLogs(query);
         }
     }
 
@@ -74,5 +75,6 @@ export class LogsPage extends React.Component<LogsPageProps, LogsPageState> {
 }
 
 export default connect(
-    mapStateToProps
+    mapStateToProps,
+    mapDispatchToProps
 )(LogsPage);

--- a/src/pages/logspage/LogsPage.tsx
+++ b/src/pages/logspage/LogsPage.tsx
@@ -45,10 +45,8 @@ export class LogsPage extends React.Component<LogsPageProps, LogsPageState> {
     }
 
     onFilter(filter: CompositeFilter) {
-        console.info("On filter " + filter.type);
         let dateFilter = filter.getFilter(TYPE_DATE) as DateFilter;
         if (dateFilter) {
-            console.info("Querying new date");
             const query = new LogQuery({
                 source: this.state.source,
                 startTime: dateFilter.startDate,
@@ -57,7 +55,6 @@ export class LogsPage extends React.Component<LogsPageProps, LogsPageState> {
             const sourceId = this.state.source.id;
 
             LogService.getLogs(query).then((value: Log[]) => {
-                console.info("New logs " + value.length);
                 this.state.logMap = {
                     [sourceId]: {
                         logs: value,

--- a/src/pages/logspage/LogsPage.tsx
+++ b/src/pages/logspage/LogsPage.tsx
@@ -1,18 +1,25 @@
 import * as React from "react";
 import { connect } from "react-redux";
 
+import Log from "../../models/log";
+import LogQuery from "../../models/log-query";
 import Source from "../../models/source";
 import { State } from "../../reducers";
 import { LogMap } from "../../reducers/log";
+import { CompositeFilter, DateFilter, TYPE_DATE } from "./Filters";
 import LogsExplorer from "./LogsExplorer";
+
+import LogService from "../../services/log";
 
 export interface LogsPageProps {
     logMap: LogMap;
     source: Source;
-    params?: any;
 }
 
-interface LogsPageState { }
+interface LogsPageState {
+    logMap: LogMap;
+    source: Source;
+}
 
 function mapStateToProps(state: State.All) {
     return {
@@ -23,9 +30,48 @@ function mapStateToProps(state: State.All) {
 
 export class LogsPage extends React.Component<LogsPageProps, LogsPageState> {
 
+    constructor(props: LogsPageProps) {
+        super(props);
+        this.state = {
+            logMap: props.logMap,
+            source: props.source
+        };
+    }
+
+    componentWillReceiveProps(props: LogsPageProps, context: any) {
+        this.state.logMap = props.logMap;
+        this.state.source = props.source;
+        this.setState(this.state);
+    }
+
+    onFilter(filter: CompositeFilter) {
+        console.info("On filter " + filter.type);
+        let dateFilter = filter.getFilter(TYPE_DATE) as DateFilter;
+        if (dateFilter) {
+            console.info("Querying new date");
+            const query = new LogQuery({
+                source: this.state.source,
+                startTime: dateFilter.startDate,
+                endTime: dateFilter.endDate
+            });
+            const sourceId = this.state.source.id;
+
+            LogService.getLogs(query).then((value: Log[]) => {
+                console.info("New logs " + value.length);
+                this.state.logMap = {
+                    [sourceId]: {
+                        logs: value,
+                        query: query
+                    }
+                };
+                this.setState(this.state);
+            });
+        }
+    }
+
     render() {
         return (
-            <LogsExplorer source={this.props.source} logMap={this.props.logMap} />
+            <LogsExplorer source={this.state.source} logMap={this.state.logMap} onFilter={this.onFilter.bind(this)} />
         );
     }
 }

--- a/src/services/log.ts
+++ b/src/services/log.ts
@@ -3,7 +3,7 @@ import "isomorphic-fetch";
 import Log from "../models/log";
 import LogQuery from "../models/log-query";
 
-export namespace log {
+namespace LogService {
 
     export function getLogs(query: LogQuery): Promise<Log[]> {
 
@@ -26,4 +26,4 @@ export namespace log {
     }
 }
 
-export default log;
+export default LogService;

--- a/typings.json
+++ b/typings.json
@@ -34,6 +34,7 @@
     "sinon-chai": "registry:dt/sinon-chai#2.7.0+20160317120654"
   },
   "dependencies": {
+    "chai-datetime": "registry:dt/chai-datetime#0.0.0+20160510010627",
     "d3-scale": "registry:dt/d3-scale#1.0.0+20161207020330",
     "d3-time": "registry:dt/d3-time#1.0.0+20161207020330"
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -30,5 +30,6 @@
 /// <reference path="globals/redux/index.d.ts" />
 /// <reference path="globals/sinon-chai/index.d.ts" />
 /// <reference path="globals/sinon/index.d.ts" />
+/// <reference path="modules/chai-datetime/index.d.ts" />
 /// <reference path="modules/d3-scale/index.d.ts" />
 /// <reference path="modules/d3-time/index.d.ts" />


### PR DESCRIPTION
Fixes #121

Changes in this pull request include:
- Add chai-datetime which allows for better date comparisons.
- User can not query logs all the way to the beginning of time.
- LogsPage now queries independently from the state of the app.  This means that:
- - On load, it will take the current default (last week).
- - The user can filter different dates. -> The logs page will query new logs.  These logs will *not* change the state of the website.
