### PR TITLE
Page swap

### DIFF
--- a/src/components/FormInput.tsx
+++ b/src/components/FormInput.tsx
@@ -1,5 +1,4 @@
 import * as classNames from "classnames";
-import * as objectAssign from "object-assign";
 import * as React from "react";
 
 import { COLORS } from "../constants";
@@ -27,6 +26,7 @@ export interface ErrorHandler {
 
 export interface FormInputTheme {
     inputTextColor: string;
+    bottomBorderColor?: string;
 };
 
 interface FormInputProps {
@@ -67,7 +67,22 @@ export class FormInput extends MDLComponent<FormInputProps, FormState> {
     }
 
     inputStyle(): React.CSSProperties {
-        return objectAssign({}, { color: this.props.theme ? this.props.theme.inputTextColor : undefined });
+        if (!this.props.theme) {
+            return undefined;
+        }
+
+        const theme = this.props.theme;
+        let style = {};
+
+        if (theme.inputTextColor) {
+            style = {...style, ... { color: theme.inputTextColor }};
+        }
+
+        if (theme.bottomBorderColor) {
+            style = {...style, ... { borderBottomColor: theme.bottomBorderColor }};
+        }
+
+        return style;
     }
 
     onFormChange(event: React.FormEvent) {

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -15,12 +15,15 @@ describe("Header", function () {
     describe("without any properties", function () {
 
         const wrapper = shallow(<Header />);
+
         it("renders the main header div", function () {
             expect(wrapper.find("header")).to.have.length(1);
         });
+
         it("does not render the home Link", function () {
             expect(wrapper.find("Link")).to.have.length(0);
         });
+
         it("renders the menu", function () {
             expect(wrapper.find("StyledMenu")).to.have.length(1);
         });
@@ -40,6 +43,7 @@ describe("Header", function () {
             expect(wrapper.find("span")).to.have.length(1);
             expect(wrapper.find("span").text()).to.have.equal("name");
         });
+
         it("does not render the Dropdown", function () {
             expect(wrapper.find(Dropdown)).to.have.length(0);
         });
@@ -68,9 +72,11 @@ describe("Header", function () {
         it("does not render the label span", function () {
             expect(wrapper.find("span")).to.have.length(0);
         });
+
         it("renders the dropdown", function () {
             expect(wrapper.find(Dropdown)).to.have.length(1);
         });
+
         it("updates the selectedSourceId on receiving props", function () {
             wrapper.setProps({ currentSourceId: "id" });
             expect(componentWillReceivePropsSpy).to.have.been.calledOnce;
@@ -78,6 +84,7 @@ describe("Header", function () {
             expect(setStateSpy).to.have.been.calledOnce;
             expect(setStateSpy).to.have.been.calledWith({ selectedSourceId: "id" });
         });
+
         it("calls the onSourceSelected prop", function() {
             // need to go untyped here so we can call the method on the component
             let instance =  wrapper.instance() as any;

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -214,11 +214,11 @@ describe("Header", function () {
             });
 
             it("Tests the buttons are rendered properly.", function() {
-                expect(wrapper.find(IconButton)).to.have.length(pages.length);
+                expect(wrapper.find("Themed")).to.have.length(pages.length);
             });
 
             it ("Tests the callback", function() {
-                const buttons = wrapper.find(IconButton).at(0);
+                const buttons = wrapper.find("Themed").at(0);
                 buttons.simulate("click", pages[0]);
                 expect(onPageSelected).to.have.been.calledOnce;
                 expect(onPageSelected).to.have.been.calledWith(pages[0]);

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -1,11 +1,12 @@
 import * as chai from "chai";
 import { shallow, ShallowWrapper } from "enzyme";
 import * as React from "react";
+import { IconButton } from "react-toolbox/lib/button";
 import Dropdown from "react-toolbox/lib/dropdown";
 import * as sinon from "sinon";
 import * as sinonChai from "sinon-chai";
 
-import { Header, HeaderProps, HeaderState } from "./Header";
+import { Header, HeaderProps, HeaderState, Home, PageButton, PageSwap, Title } from "./Header";
 
 // Setup chai with sinon-chai
 chai.use(sinonChai);
@@ -20,8 +21,12 @@ describe("Header", function () {
             expect(wrapper.find("header")).to.have.length(1);
         });
 
-        it("does not render the home Link", function () {
-            expect(wrapper.find("Link")).to.have.length(0);
+        it("Renders the home Link", function () {
+            expect(wrapper.find(Home)).to.have.length(1);
+        });
+
+        it("Renders the page swapper", function () {
+            expect(wrapper.find(PageSwap)).to.have.length(1);
         });
 
         it("renders the menu", function () {
@@ -29,23 +34,73 @@ describe("Header", function () {
         });
     });
 
-    describe("with displayHomeButton true", function () {
-        const wrapper = shallow(<Header displayHomeButton={true} />);
+    describe("DisplayHome property", function () {
+
         it("displays a Link to home", function () {
-            expect(wrapper.find("Link")).to.have.length(1);
+            const wrapper = shallow(<Header displayHomeButton={true} />);
+            const homeWrapper = wrapper.find(Home);
+            expect(homeWrapper).to.have.length(1);
+            expect(homeWrapper.prop("showHome")).to.be.true;
+        });
+
+        describe("Home button", function () {
+
+            let handleHomeClick: Sinon.SinonStub;
+
+            before(function () {
+                handleHomeClick = sinon.stub();
+            });
+
+            beforeEach(function () {
+                handleHomeClick.reset();
+            });
+
+            it("Displays the button when props say true.", function () {
+                const wrapper = shallow(<Home handleHomeClick={handleHomeClick} showHome={true} />);
+                expect(wrapper.find(IconButton)).to.have.length(1);
+            });
+
+            it("Displays the button when props say true.", function () {
+                const wrapper = shallow(<Home handleHomeClick={handleHomeClick} showHome={false} />);
+                expect(wrapper.find(IconButton)).to.have.length(0);
+            });
+
+            it("Calls the callback when clicked.", function () {
+                const wrapper = shallow(<Home handleHomeClick={handleHomeClick} showHome={true} />);
+                const iconButton = wrapper.find(IconButton).at(0);
+                iconButton.simulate("click");
+                expect(handleHomeClick).to.have.been.calledOnce;
+            });
         });
     });
 
     describe("with one source", function () {
+        const sources = [{ label: "name", value: "id" }];
         const wrapper = shallow(<Header sources={[{ label: "name", value: "id" }]} />);
 
-        it("renders the label span", function () {
-            expect(wrapper.find("span")).to.have.length(1);
-            expect(wrapper.find("span").text()).to.have.equal("name");
+        it("renders the title", function () {
+            const titleWrapper = wrapper.find(Title);
+            expect(titleWrapper).to.have.length(1);
+            expect(titleWrapper.prop("sources")).to.deep.equal(sources);
         });
 
-        it("does not render the Dropdown", function () {
-            expect(wrapper.find(Dropdown)).to.have.length(0);
+        describe("Title", function () {
+
+            let handleItemSelect: Sinon.SinonStub;
+
+            before(function () {
+                handleItemSelect = sinon.stub();
+            });
+
+            beforeEach(function () {
+                handleItemSelect.reset();
+            });
+
+            it("Renders the span with only one source.", function () {
+                const wrapper = shallow(<Title handleItemSelect={handleItemSelect} selectedSourceId={""} sources={sources} />);
+                expect(wrapper.find("span")).to.have.length(1);
+                expect(wrapper.find("span").text()).to.have.equal("name");
+            });
         });
     });
 
@@ -54,13 +109,14 @@ describe("Header", function () {
         const componentWillReceivePropsSpy = sinon.spy(Header.prototype, "componentWillReceiveProps");
         const setStateSpy = sinon.spy(Header.prototype, "setState");
         const onSourceSelectedSpy = sinon.spy();
+        const sources = [{ label: "name", value: "id" }, { label: "name1", value: "id1" }, { label: "name2", value: "id2" }, { label: "name3", value: "id3" }];
 
         beforeEach(function () {
             wrapper = shallow((
                 <Header
                     onSourceSelected={onSourceSelectedSpy}
-                    sources={[{ label: "name", value: "id" }, { label: "name1", value: "id1" }, { label: "name2", value: "id2" }, { label: "name3", value: "id3" }]}
-                    />
+                    sources={sources}
+                />
             ));
         });
 
@@ -69,12 +125,10 @@ describe("Header", function () {
             setStateSpy.reset();
         });
 
-        it("does not render the label span", function () {
-            expect(wrapper.find("span")).to.have.length(0);
-        });
-
-        it("renders the dropdown", function () {
-            expect(wrapper.find(Dropdown)).to.have.length(1);
+        it("renders the title", function () {
+            const titleWrapper = wrapper.find(Title);
+            expect(titleWrapper).to.have.length(1);
+            expect(titleWrapper.prop("sources")).to.equal(sources);
         });
 
         it("updates the selectedSourceId on receiving props", function () {
@@ -83,15 +137,92 @@ describe("Header", function () {
             expect(wrapper.state().selectedSourceId).to.equal("id");
             expect(setStateSpy).to.have.been.calledOnce;
             expect(setStateSpy).to.have.been.calledWith({ selectedSourceId: "id" });
+
+            const titleWrapper = wrapper.find(Title);
+            expect(titleWrapper.prop("selectedSourceId")).to.equal("id");
         });
 
-        it("calls the onSourceSelected prop", function() {
+        it("calls the onSourceSelected prop", function () {
             // need to go untyped here so we can call the method on the component
-            let instance =  wrapper.instance() as any;
+            let instance = wrapper.instance() as any;
             instance.handleItemSelect("id");
 
             expect(onSourceSelectedSpy).to.have.been.calledOnce;
             expect(onSourceSelectedSpy).to.have.been.calledWith({ label: "name", value: "id" });
+        });
+
+        describe("Title", function () {
+
+            let handleItemSelect: Sinon.SinonStub;
+            let wrapper: ShallowWrapper<any, any>;
+
+            before(function () {
+                handleItemSelect = sinon.stub();
+                wrapper = shallow((
+                    <Title
+                        sources={sources}
+                        handleItemSelect={handleItemSelect}
+                        selectedSourceId={"id"} />
+                ));
+            });
+
+            beforeEach(function () {
+                handleItemSelect.reset();
+            });
+
+            it("Tests the title renders the Dropdown.", function () {
+                const dropdownWrapper = wrapper.find(Dropdown);
+                expect(dropdownWrapper).to.have.length(1);
+                expect(dropdownWrapper.prop("source")).to.deep.equal(sources);
+                expect(dropdownWrapper.prop("value")).to.equal("id");
+            });
+
+            it("Tests the handle Item callback is returned on dropdown select.", function () {
+                const dropdownWrapper = wrapper.find(Dropdown);
+                dropdownWrapper.simulate("change", "id2");
+                expect(handleItemSelect).to.have.been.calledOnce;
+                expect(handleItemSelect).to.be.calledWith("id2");
+            });
+        });
+    });
+
+    describe("Page swapper", function () {
+        const pages: PageButton[] = [{ icon: "home", name: "heeyyooo" }, { icon: "away", name: "fancy" }];
+
+        let onPageSelected: Sinon.SinonStub;
+
+        before(function () {
+            onPageSelected = sinon.stub();
+        });
+
+        beforeEach(function () {
+            onPageSelected.reset();
+        });
+
+        it("Tests the header passes the appropriate props to the page swap", function () {
+            const wrapper = shallow(<Header pageButtons={pages} onPageSelected={onPageSelected} />);
+            const pageswap = wrapper.find(PageSwap);
+            expect(pageswap.prop("pageButtons")).to.deep.equal(pages);
+            expect(pageswap.prop("onPageSelected")).to.equal(onPageSelected);
+        });
+
+        describe("PageSwap", function () {
+            let wrapper: ShallowWrapper<any, any>;
+
+            beforeEach(function() {
+                wrapper = shallow(<PageSwap pageButtons={pages} onPageSelected={onPageSelected} />);
+            });
+
+            it("Tests the buttons are rendered properly.", function() {
+                expect(wrapper.find(IconButton)).to.have.length(pages.length);
+            });
+
+            it ("Tests the callback", function() {
+                const buttons = wrapper.find(IconButton).at(0);
+                buttons.simulate("click", pages[0]);
+                expect(onPageSelected).to.have.been.calledOnce;
+                expect(onPageSelected).to.have.been.calledWith(pages[0]);
+            });
         });
     });
 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,8 @@ import Dropdown from "react-toolbox/lib/dropdown";
 
 import { Menu, MenuItem } from "../components/Menu";
 
+import Noop from "../utils/NoOp";
+
 const DropdownDarkTheme = require("../themes/dropdown-dark-nolabel.scss");
 
 export interface Dropdownable {
@@ -14,7 +16,7 @@ export interface Dropdownable {
 
 export interface HeaderProps {
   currentSourceId?: string;
-  sources?: Array<Dropdownable>;
+  sources?: Dropdownable[];
   onSourceSelected?: (source: Dropdownable) => void;
   displayHomeButton?: boolean;
   className?: string;
@@ -58,23 +60,6 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
   }
 
   render() {
-    let title: JSX.Element = undefined;
-    if (this.props.sources && this.props.sources.length > 0) {
-      if (this.props.sources.length === 1) {
-        title = (<span className="mdl-layout-title">{this.props.sources[0].label}</span>);
-      } else {
-        title = (
-          <Dropdown
-            theme={DropdownDarkTheme}
-            auto
-            onChange={this.handleItemSelect}
-            source={this.props.sources}
-            value={this.state.selectedSourceId}
-            />
-        );
-      }
-    }
-
     return (
       <header className={this.classes()}>
         <div className="mdl-layout__header-row" style={{ paddingLeft: "0px" }}>
@@ -83,7 +68,10 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
               <i className="material-icons" role="presentation">home</i>
             </Link>
           ) : undefined}
-          {title}
+          <Title
+            sources={this.props.sources}
+            handleItemSelect={this.handleItemSelect}
+            selectedSourceId={this.state.selectedSourceId} />
           <div className="mdl-layout-spacer" />
           {this.props.children}
 
@@ -94,7 +82,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
             <MenuItem
               to="https://github.com/bespoken/dashboard/issues/new?labels=bug"
               icon="bug_report"
-              caption="File Bug"/>
+              caption="File Bug" />
             <MenuItem
               to="https://github.com/bespoken/dashboard/issues/new?labels=feature%20request&body="
               icon="build"
@@ -115,3 +103,47 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
 }
 
 export default Header;
+
+interface TitleProps {
+  handleItemSelect: (value: string) => void;
+  sources: Dropdownable[];
+  selectedSourceId: string;
+}
+
+class Title extends React.Component<TitleProps, any> {
+
+  static defaultProps: TitleProps = {
+    handleItemSelect: Noop,
+    sources: [],
+    selectedSourceId: ""
+  };
+
+  constructor(props: TitleProps) {
+    super(props);
+
+    this.state = {
+      selectedSourceId: undefined
+    };
+  }
+
+  render() {
+    let title: JSX.Element = (<div/>);
+    if (this.props.sources.length > 0) {
+      if (this.props.sources.length === 1) {
+        title = (<span className="mdl-layout-title">{this.props.sources[0].label}</span>);
+      } else {
+        title = (
+          <Dropdown
+            theme={DropdownDarkTheme}
+            auto
+            onChange={this.props.handleItemSelect}
+            source={this.props.sources}
+            value={this.props.selectedSourceId}
+          />
+        );
+      }
+    }
+
+    return title;
+  }
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -129,7 +129,7 @@ interface HomeProps {
   showHome: boolean;
 }
 
-class Home extends React.Component<HomeProps, any> {
+export class Home extends React.Component<HomeProps, any> {
   render() {
     let home: JSX.Element = (<div />);
     if (this.props.showHome) {
@@ -152,7 +152,7 @@ interface TitleProps {
   selectedSourceId: string;
 }
 
-class Title extends React.Component<TitleProps, any> {
+export class Title extends React.Component<TitleProps, any> {
 
   static defaultProps: TitleProps = {
     handleItemSelect: Noop,
@@ -199,7 +199,7 @@ interface PageSwapState {
   buttons: JSX.Element[];
 }
 
-class PageSwap extends React.Component<PageSwapProps, PageSwapState> {
+export class PageSwap extends React.Component<PageSwapProps, PageSwapState> {
 
   static defaultProps: PageSwapProps = {
     pageButtons: [],

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import * as classNames from "classnames";
 import * as React from "react";
 import { Link } from "react-router";
+import { IconButton } from "react-toolbox/lib/button";
 import Dropdown from "react-toolbox/lib/dropdown";
 
 import { Menu, MenuItem } from "../components/Menu";
@@ -14,10 +15,17 @@ export interface Dropdownable {
   label: string;
 }
 
+export interface PageButton {
+  name: string;
+  icon: string | JSX.Element; // String or <svg/>
+}
+
 export interface HeaderProps {
   currentSourceId?: string;
   sources?: Dropdownable[];
   onSourceSelected?: (source: Dropdownable) => void;
+  pageButtons?: PageButton[];
+  onPageSelected?: (button: PageButton) => void;
   displayHomeButton?: boolean;
   className?: string;
 }
@@ -72,6 +80,9 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
             sources={this.props.sources}
             handleItemSelect={this.handleItemSelect}
             selectedSourceId={this.state.selectedSourceId} />
+          <PageSwap
+            pageButtons={this.props.pageButtons}
+            onPageSelected={this.props.onPageSelected} />
           <div className="mdl-layout-spacer" />
           {this.props.children}
 
@@ -127,7 +138,7 @@ class Title extends React.Component<TitleProps, any> {
   }
 
   render() {
-    let title: JSX.Element = (<div/>);
+    let title: JSX.Element = (<div />);
     if (this.props.sources.length > 0) {
       if (this.props.sources.length === 1) {
         title = (<span className="mdl-layout-title">{this.props.sources[0].label}</span>);
@@ -145,5 +156,64 @@ class Title extends React.Component<TitleProps, any> {
     }
 
     return title;
+  }
+}
+
+interface PageSwapProps {
+  pageButtons?: PageButton[];
+  onPageSelected?: (button: PageButton) => void | undefined;
+}
+
+interface PageSwapState {
+  buttons: JSX.Element[];
+}
+
+class PageSwap extends React.Component<PageSwapProps, PageSwapState> {
+
+  static defaultProps: PageSwapProps = {
+    pageButtons: [],
+    onPageSelected: Noop
+  };
+
+  constructor(props: PageSwapProps) {
+    super(props);
+
+    this.state = { buttons: [] };
+  }
+
+  componentWillReceiveProps(props: PageSwapProps, context: any) {
+    this.buildButtons(props);
+  }
+
+  componentWillMount() {
+    this.buildButtons(this.props);
+  }
+
+  handleSelected(button: PageButton) {
+    this.props.onPageSelected(button);
+  }
+
+  buildButtons(props: PageSwapProps) {
+    const buttons = props.pageButtons;
+    this.state.buttons = [];
+    for (let button of buttons) {
+      this.state.buttons.push(
+        (
+          <IconButton
+            accent
+            key={button.name}
+            icon={button.icon}
+            onClick={this.handleSelected.bind(this, button)} />
+        )
+      );
+    };
+  }
+
+  render() {
+    return (
+      <div>
+        {this.state.buttons}
+      </div>
+    );
   }
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,7 +5,7 @@ import Dropdown from "react-toolbox/lib/dropdown";
 
 import { Menu, MenuItem } from "../components/Menu";
 
-import Noop from "../utils/NoOp";
+import Noop from "../utils/Noop";
 
 const DropdownDarkTheme = require("../themes/dropdown-dark-nolabel.scss");
 const IconButtonTheme = require("../themes/icon-button-primary.scss");

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@ import * as classNames from "classnames";
 import * as React from "react";
 import { IconButton } from "react-toolbox/lib/button";
 import Dropdown from "react-toolbox/lib/dropdown";
+import Tooltip from "react-toolbox/lib/tooltip";
 
 import { Menu, MenuItem } from "../components/Menu";
 
@@ -199,6 +200,8 @@ interface PageSwapState {
   buttons: JSX.Element[];
 }
 
+const TooltipButton = Tooltip(IconButton);
+
 export class PageSwap extends React.Component<PageSwapProps, PageSwapState> {
 
   static defaultProps: PageSwapProps = {
@@ -230,11 +233,13 @@ export class PageSwap extends React.Component<PageSwapProps, PageSwapState> {
     for (let button of buttons) {
       this.state.buttons.push(
         (
-          <IconButton
+          <TooltipButton
             theme={IconButtonTheme}
             accent
             key={button.name}
+            tooltip={button.name}
             icon={button.icon}
+            tooltipDelay={1000}
             onClick={this.handleSelected.bind(this, button)} />
         )
       );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,5 @@
 import * as classNames from "classnames";
 import * as React from "react";
-// import { Link } from "react-router";
 import { IconButton } from "react-toolbox/lib/button";
 import Dropdown from "react-toolbox/lib/dropdown";
 
@@ -9,6 +8,7 @@ import { Menu, MenuItem } from "../components/Menu";
 import Noop from "../utils/NoOp";
 
 const DropdownDarkTheme = require("../themes/dropdown-dark-nolabel.scss");
+const IconButtonTheme = require("../themes/icon-button-primary.scss");
 
 export interface Dropdownable {
   value: string;
@@ -135,6 +135,7 @@ class Home extends React.Component<HomeProps, any> {
     if (this.props.showHome) {
       home = (
         <IconButton
+          theme={IconButtonTheme}
           accent
           onClick={this.props.handleHomeClick}
           icon="home" />
@@ -230,6 +231,7 @@ class PageSwap extends React.Component<PageSwapProps, PageSwapState> {
       this.state.buttons.push(
         (
           <IconButton
+            theme={IconButtonTheme}
             accent
             key={button.name}
             icon={button.icon}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -239,7 +239,6 @@ export class PageSwap extends React.Component<PageSwapProps, PageSwapState> {
             key={button.name}
             tooltip={button.name}
             icon={button.icon}
-            tooltipDelay={1000}
             onClick={this.handleSelected.bind(this, button)} />
         )
       );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import * as classNames from "classnames";
 import * as React from "react";
-import { Link } from "react-router";
+// import { Link } from "react-router";
 import { IconButton } from "react-toolbox/lib/button";
 import Dropdown from "react-toolbox/lib/dropdown";
 
@@ -23,6 +23,7 @@ export interface PageButton {
 export interface HeaderProps {
   currentSourceId?: string;
   sources?: Dropdownable[];
+  onHomeClicked?: () => void;
   onSourceSelected?: (source: Dropdownable) => void;
   pageButtons?: PageButton[];
   onPageSelected?: (button: PageButton) => void;
@@ -71,41 +72,49 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     return (
       <header className={this.classes()}>
         <div className="mdl-layout__header-row" style={{ paddingLeft: "0px" }}>
-          {this.props.displayHomeButton ? (
-            <Link to={"/"} style={{ paddingLeft: "15px", paddingRight: "15px" }}>
-              <i className="material-icons" role="presentation">home</i>
-            </Link>
-          ) : undefined}
+
+          <Home
+            handleHomeClick={this.props.onHomeClicked}
+            showHome={this.props.displayHomeButton} />
+
           <Title
             sources={this.props.sources}
             handleItemSelect={this.handleItemSelect}
             selectedSourceId={this.state.selectedSourceId} />
+
           <PageSwap
             pageButtons={this.props.pageButtons}
             onPageSelected={this.props.onPageSelected} />
+
           <div className="mdl-layout-spacer" />
+
           {this.props.children}
 
           <Menu
             icon="help_outline"
             position="topRight"
             menuRipple>
+
             <MenuItem
               to="https://github.com/bespoken/dashboard/issues/new?labels=bug"
               icon="bug_report"
               caption="File Bug" />
+
             <MenuItem
               to="https://github.com/bespoken/dashboard/issues/new?labels=feature%20request&body="
               icon="build"
               caption="Request Feature" />
+
             <MenuItem
               to="https://gitter.im/bespoken/bst?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"
               icon="question_answer"
               caption="Talk to Us" />
+
             <MenuItem
               to="mailto:contact@bespoken.tools"
               icon="email"
               caption="Email" />
+
           </Menu>
         </div>
       </header>
@@ -114,6 +123,27 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
 }
 
 export default Header;
+
+interface HomeProps {
+  handleHomeClick: () => void;
+  showHome: boolean;
+}
+
+class Home extends React.Component<HomeProps, any> {
+  render() {
+    let home: JSX.Element = (<div />);
+    if (this.props.showHome) {
+      home = (
+        <IconButton
+          accent
+          onClick={this.props.handleHomeClick}
+          icon="home" />
+      );
+    }
+
+    return home;
+  }
+}
 
 interface TitleProps {
   handleItemSelect: (value: string) => void;

--- a/src/frames/Dashboard.tsx
+++ b/src/frames/Dashboard.tsx
@@ -82,6 +82,7 @@ class Dashboard extends React.Component<DashboardProps, DashboardState> {
 
     this.handleSelectedSource = this.handleSelectedSource.bind(this);
     this.handlePageSwap = this.handlePageSwap.bind(this);
+    this.handleHomeClick = this.handleHomeClick.bind(this);
   }
 
   drawerClasses() {
@@ -153,6 +154,10 @@ class Dashboard extends React.Component<DashboardProps, DashboardState> {
     }
   }
 
+  handleHomeClick() {
+    this.props.goTo("/");
+  }
+
   render() {
     return (
       <Layout header={true}>
@@ -163,6 +168,7 @@ class Dashboard extends React.Component<DashboardProps, DashboardState> {
           pageButtons={this.pageButtons()}
           onPageSelected={this.handlePageSwap}
           onSourceSelected={this.handleSelectedSource}
+          onHomeClicked={this.handleHomeClick}
           displayHomeButton={this.props.location.pathname !== "/"}>
           <UserControl
             login={this.props.login}

--- a/src/frames/Dashboard.tsx
+++ b/src/frames/Dashboard.tsx
@@ -6,7 +6,7 @@ import { push, replace } from "react-router-redux";
 import { logout } from "../actions/session";
 import { getSources, setCurrentSource } from "../actions/source";
 import Content from "../components/Content";
-import { Dropdownable, Header, } from "../components/Header";
+import { Dropdownable, Header, PageButton } from "../components/Header";
 import Layout from "../components/Layout";
 import UserControl from "../components/UserControl";
 import { CLASSES } from "../constants";
@@ -77,6 +77,13 @@ function mapDispatchToProps(dispatch: any) {
 
 class Dashboard extends React.Component<DashboardProps, DashboardState> {
 
+  constructor(props: DashboardProps) {
+    super(props);
+
+    this.handleSelectedSource = this.handleSelectedSource.bind(this);
+    this.handlePageSwap = this.handlePageSwap.bind(this);
+  }
+
   drawerClasses() {
     return classNames(CLASSES.TEXT.BLUE_GREY_50, CLASSES.COLOR.BLUE_GREY_900);
   }
@@ -121,6 +128,31 @@ class Dashboard extends React.Component<DashboardProps, DashboardState> {
     return -1;
   }
 
+  pageButtons(): PageButton[] | undefined {
+    if (this.props.currentSource) {
+      return [
+        {
+          icon: "dashboard",
+          name: "summary"
+        },
+        {
+          icon: "list",
+          name: "logs"
+        }
+      ];
+    } else {
+      return undefined;
+    }
+  }
+
+  handlePageSwap(button: PageButton) {
+    if (button.name === "summary") {
+      this.props.goTo("/skills/" + this.props.currentSource.id);
+    } else if (button.name === "logs") {
+      this.props.goTo("/skills/" + this.props.currentSource.id + "/logs");
+    }
+  }
+
   render() {
     return (
       <Layout header={true}>
@@ -128,7 +160,9 @@ class Dashboard extends React.Component<DashboardProps, DashboardState> {
           className={this.headerClasses()}
           currentSourceId={this.props.currentSource ? this.props.currentSource.id : undefined}
           sources={this.props.currentSource ? this.dropdownableSources() : undefined}
-          onSourceSelected={this.handleSelectedSource.bind(this)}
+          pageButtons={this.pageButtons()}
+          onPageSelected={this.handlePageSwap}
+          onSourceSelected={this.handleSelectedSource}
           displayHomeButton={this.props.location.pathname !== "/"}>
           <UserControl
             login={this.props.login}

--- a/src/pages/SourcePage.tsx
+++ b/src/pages/SourcePage.tsx
@@ -171,6 +171,7 @@ export class SourcePage extends React.Component<SourcePageProps, SourcePageState
     }
 
     render() {
+        const tileColor = "#ECEFF1";
         return (
             <span>
                 {this.props.source ? (
@@ -178,25 +179,25 @@ export class SourcePage extends React.Component<SourcePageProps, SourcePageState
                         <Grid style={{ backgroundColor: "rgb(36, 48, 54)", paddingBottom: "0px", paddingTop: "0px" }}>
                             <Cell col={3} hidePhone={true}>
                                 <DataTile
-                                    theme={{ inputTextColor: "#ECEFF1" }}
+                                    theme={{ inputTextColor: tileColor, bottomBorderColor: tileColor }}
                                     value={this.props.source.name}
                                     label={"Name"} />
                             </Cell>
                             <Cell col={3} hidePhone={true} >
                                 <DataTile
-                                    theme={{ inputTextColor: "#ECEFF1" }}
+                                    theme={{ inputTextColor: tileColor, bottomBorderColor: tileColor }}
                                     value={this.props.source.id}
                                     label={"ID"} />
                             </Cell>
                             <Cell col={3} hidePhone={true} >
                                 <DataTile
-                                    theme={{ inputTextColor: "#ECEFF1" }}
+                                    theme={{ inputTextColor: tileColor, bottomBorderColor: tileColor }}
                                     value={moment(this.props.source.created).format("MMM Do, YYYY")}
                                     label={"Created"} />
                             </Cell>
                             <Cell col={3} hidePhone={true} >
                                 <DataTile
-                                    theme={{ inputTextColor: "#ECEFF1" }}
+                                    theme={{ inputTextColor: tileColor, bottomBorderColor: tileColor }}
                                     value={this.props.source.secretKey}
                                     label={"Secret Key"}
                                     hidden={true}

--- a/src/pages/SourcePage.tsx
+++ b/src/pages/SourcePage.tsx
@@ -1,9 +1,7 @@
 import * as moment from "moment";
 import * as React from "react";
 import { connect } from "react-redux";
-import { Link } from "react-router";
 
-import Button from "../components/Button";
 import DataTile from "../components/DataTile";
 import BarChart, { CountData } from "../components/Graphs/Bar/CountChart";
 import TimeChart, { TimeData } from "../components/Graphs/Line/TimeChart";
@@ -71,7 +69,7 @@ export class SourcePage extends React.Component<SourcePageProps, SourcePageState
     }
 
     componentWillReceiveProps(nextProps: SourcePageProps, context: any) {
-        if (!this.props.source || !nextProps.source.id || this.props.source.id !== nextProps.source.id) {
+        if (!this.props.source || !nextProps.source || this.props.source.id !== nextProps.source.id) {
             this.retrieveTimeSummary(nextProps.source);
             this.retrieveIntentSummary(nextProps.source);
             this.retrieveSourceStats(nextProps.source);
@@ -203,16 +201,6 @@ export class SourcePage extends React.Component<SourcePageProps, SourcePageState
                                     label={"Secret Key"}
                                     hidden={true}
                                     showable={true} />
-                            </Cell>
-                        </Grid>
-                        <Grid>
-                            <Cell col={3}>
-                                <p style={{ fontSize: "16px", fontFamily: "Roboto, Helvetica" }}>What would you like to do? </p>
-                            </Cell>
-                            <Cell col={3}>
-                                <Link to={"/skills/" + this.props.source.id + "/logs"}>
-                                    <Button raised={true} ripple={true}>View Logs</Button>
-                                </Link>
                             </Cell>
                         </Grid>
                     </span>

--- a/src/themes/dashboard.scss
+++ b/src/themes/dashboard.scss
@@ -5,6 +5,8 @@
 
 $color-primary: rgb(255, 69, 69);
 
+$color-accent: $color-primary;
+
 $font-size-tiny: 0.8em;
 $font-size-small: 1.0em;
 

--- a/src/themes/icon-button-primary.scss
+++ b/src/themes/icon-button-primary.scss
@@ -1,0 +1,3 @@
+@import "dashboard";
+@import "~react-toolbox/lib/button/config";
+@import "~react-toolbox/lib/button/theme";

--- a/src/utils/Noop.ts
+++ b/src/utils/Noop.ts
@@ -1,0 +1,8 @@
+/**
+ * A NoOperation function that does nothing.  It's better to have this exist and pass it around
+ * than to create a new one throughout the entire life of the program.  Just import it and go.
+ */
+
+export default function noOp() {
+
+}


### PR DESCRIPTION
Fixes #138

Changes in this pull request include:
- User can now go back and forth between summary page and logs list by buttons on the top.
- UI enhancements.