### PR TITLE
Summary Sort

### DIFF
--- a/src/components/Graphs/Line/TimeChart.test.tsx
+++ b/src/components/Graphs/Line/TimeChart.test.tsx
@@ -53,6 +53,30 @@ describe("CountChart", function () {
         });
     });
 
+    describe("TimeData tests", function() {
+        it("Tests that compare returns 0 on equal.", function() {
+            const b1 = new TimeData(new Date(2017, 5, 5, 5, 5));
+            const b2 = new TimeData(new Date(2017, 5, 5, 5, 5));
+
+            expect(b1.compare(b2)).to.equal(0);
+            expect(b2.compare(b1)).to.equal(0);
+        });
+
+        it("Tests that compare returns negative when b1 is later than b2.", function() {
+            const b1 = new TimeData(new Date(2017, 5, 5, 5, 4));
+            const b2 = new TimeData(new Date(2017, 5, 5, 5, 5));
+
+            expect(b1.compare(b2)).to.lessThan(0);
+        });
+
+        it("Tests that compare returns negative when b1 is sooner than b2.", function() {
+            const b1 = new TimeData(new Date(2017, 5, 5, 5, 6));
+            const b2 = new TimeData(new Date(2017, 5, 5, 5, 5));
+
+            expect(b1.compare(b2)).to.greaterThan(0);
+        });
+    });
+
     describe("Lines tests", function () {
         let wrapper: ShallowWrapper<any, any>;
         let linesWrapper: ShallowWrapper<any, any>;

--- a/src/components/Graphs/Line/TimeChart.tsx
+++ b/src/components/Graphs/Line/TimeChart.tsx
@@ -12,13 +12,15 @@ export interface LineProps {
 
 export class TimeData {
     time: Date;
+    timeValue: number;
 
     constructor(time: Date | moment.Moment) {
         this.time = (time instanceof Date) ? time : time.toDate();
+        this.timeValue = this.time.getTime();
     }
 
-    get timeValue() {
-        return this.time.getTime();
+    compare(data: TimeData) {
+        return this.timeValue - data.timeValue;
     }
 }
 

--- a/src/pages/sourcepage/SourceTimeSummary.tsx
+++ b/src/pages/sourcepage/SourceTimeSummary.tsx
@@ -161,21 +161,16 @@ function defaultPageTimeData(start: moment.Moment, end: moment.Moment): PageTime
 
 function mergeTimeSummary(summary: LogService.TimeSummary): PageTimeData[] {
     const merger: any = {};
-    for (let bucket of summary.buckets) {
-        const date = new Date(bucket.date);
-        date.setMinutes(0, 0, 0);
-        const dateString = date.toISOString();
-        const newObj: PageTimeData = new PageTimeData(date);
-        newObj["total"] = bucket.count;
-        newObj["Amazon.Alexa"] = 0;
-        newObj["Google.Home"] = 0;
-        merger[dateString] = newObj;
-    }
 
+    joinBuckets(merger, summary.buckets, "total");
     joinBuckets(merger, summary.amazonBuckets, "Amazon.Alexa");
     joinBuckets(merger, summary.googleBuckets, "Google.Home");
 
-    const values = Object.keys(merger).map(key => merger[key]);
+    const values = Object.keys(merger)
+        .map(key => merger[key])
+        .sort(function(b1: PageTimeData, b2: PageTimeData): number {
+            return b1.compare(b2);
+        });
     return values;
 }
 
@@ -187,9 +182,7 @@ function joinBuckets(merger: any, buckets: LogService.TimeBucket[], key: "total"
         let obj: PageTimeData = merger[dateString];
         if (!obj) {
             obj = new PageTimeData(date);
-            obj["total"] = bucket.count;
-            obj["Amazon.Alexa"] = 0;
-            obj["Google.Home"] = 0;
+            console.info("date" + date.toISOString());
         }
         obj[key] = bucket.count;
         merger[dateString] = obj;

--- a/src/pages/sourcepage/SourceTimeSummary.tsx
+++ b/src/pages/sourcepage/SourceTimeSummary.tsx
@@ -182,7 +182,6 @@ function joinBuckets(merger: any, buckets: LogService.TimeBucket[], key: "total"
         let obj: PageTimeData = merger[dateString];
         if (!obj) {
             obj = new PageTimeData(date);
-            console.info("date" + date.toISOString());
         }
         obj[key] = bucket.count;
         merger[dateString] = obj;


### PR DESCRIPTION
It ensures that the time summary is *always* in order.  This was to overcome a bug in the Logless server which has since been patched, but it may still be good to have.