### PR TITLE
Spokes

### DIFF
--- a/src/components/CancelableComponent.test.tsx
+++ b/src/components/CancelableComponent.test.tsx
@@ -73,9 +73,9 @@ describe("CancelableComponent", function () {
         const component = wrapper.instance() as CancelableComponent<any, any>;
 
         const promise = component.resolve("Hello");
+        expect(component.cancelables).to.have.length(1);
         return promise.then(function (obj: any) {
             expect(obj).to.equal("Hello");
-            expect(component.cancelables[0]).to.equal(promise);
         });
     });
 
@@ -83,9 +83,45 @@ describe("CancelableComponent", function () {
         const component = wrapper.instance() as CancelableComponent<any, any>;
 
         const promise = component.resolve("Hello", true);
+        expect(component.cancelOnProps).to.have.length(1);
         return promise.then(function (obj: any) {
             expect(obj).to.equal("Hello");
-            expect(component.cancelOnProps[0]).to.equal(promise);
+        });
+    });
+
+    it("Tests that the cancelable is removed when the promise is finished with normal cancelables.", function () {
+        const component = wrapper.instance() as CancelableComponent<any, any>;
+
+        console.info("RESOLVING");
+        const promise = component.resolve("Hello");
+        return promise.then(function (obj: any) {
+            expect(component.cancelables).to.have.length(0);
+        });
+    });
+
+    it("Tests that the cancelable is removed when the promise is finished with props cancelables.", function () {
+        const component = wrapper.instance() as CancelableComponent<any, any>;
+
+        const promise = component.resolve("Hello", true);
+        return promise.then(function (obj: any) {
+            expect(component.cancelOnProps).to.have.length(0);
+        });
+    });
+
+    it("Tests that the cancelable is removed from the middle of the stack when finished.", function () {
+        const component = wrapper.instance() as CancelableComponent<any, any>;
+        component.resolve("Hello", true);
+        component.resolve("Hello", true);
+        const promise2 = component.resolve("Hello", true);
+        component.resolve("Hello", true);
+
+        return promise2.then(function () {
+            for (let c of component.cancelables) {
+                expect(c).to.not.equal(promise2);
+            }
+            for (let c of component.cancelOnProps) {
+                expect(c).to.not.equal(promise2);
+            }
         });
     });
 });

--- a/src/components/CancelableComponent.test.tsx
+++ b/src/components/CancelableComponent.test.tsx
@@ -1,0 +1,103 @@
+import * as chai from "chai";
+import { shallow, ShallowWrapper } from "enzyme";
+import * as React from "react";
+import * as sinon from "sinon";
+import * as sinonChai from "sinon-chai";
+
+import { Cancelable, CancelableComponent } from "./CancelableComponent";
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe("CancelableComponent", function () {
+    let wrapper: ShallowWrapper<any, any>;
+
+    beforeEach(function () {
+        wrapper = shallow(<CancelableComponent />);
+    });
+
+    it("Tests the canceled components registered in the component are canceld on unmount.", function () {
+        const cancel = new CancelableObj();
+        const component = wrapper.instance() as CancelableComponent<any, any>;
+        component.registerCancelable(cancel);
+        component.registerCancelable(cancel);
+        component.registerCancelable(cancel);
+        component.registerCancelable(cancel);
+
+        wrapper.unmount();
+
+        expect(cancel.cancel).to.have.callCount(4);
+    });
+
+    it("Tests the canceled components registered in the component are canceled on props change if true.", function () {
+        const cancel = new CancelableObj();
+        const component = wrapper.instance() as CancelableComponent<any, any>;
+        component.registerCancelable(cancel, true);
+        component.registerCancelable(cancel, true);
+        component.registerCancelable(cancel, true);
+        component.registerCancelable(cancel, true);
+
+        wrapper.setProps({ new: "data" });
+
+        expect(cancel.cancel).to.have.callCount(4);
+    });
+
+    it("Tests the canceled components registered in the component are *not* called on unmount if canceled in props.", function () {
+        const cancel = new CancelableObj();
+        const component = wrapper.instance() as CancelableComponent<any, any>;
+        component.registerCancelable(cancel, true);
+        component.registerCancelable(cancel, true);
+        component.registerCancelable(cancel, true);
+        component.registerCancelable(cancel, true);
+
+        wrapper.setProps({});
+
+        wrapper.unmount();
+
+        expect(cancel.cancel).to.have.callCount(4);
+    });
+
+    it("Tests the canceled components registered in the component are canceled in unmount if props was true but no props changed.", function () {
+        const cancel = new CancelableObj();
+        const component = wrapper.instance() as CancelableComponent<any, any>;
+        component.registerCancelable(cancel, true);
+        component.registerCancelable(cancel, true);
+        component.registerCancelable(cancel, true);
+
+        wrapper.unmount();
+
+        expect(cancel.cancel).to.have.callCount(3);
+    });
+
+    it("Tests the resolve method returns a promise and registers as a cancelable.", function () {
+        const component = wrapper.instance() as CancelableComponent<any, any>;
+
+        const promise = component.resolve("Hello");
+        return promise.then(function (obj: any) {
+            expect(obj).to.equal("Hello");
+            expect(component.cancelables[0]).to.equal(promise);
+        });
+    });
+
+    it("Tests the resolve method returns a promise which can be canceled under props change..", function () {
+        const component = wrapper.instance() as CancelableComponent<any, any>;
+
+        const promise = component.resolve("Hello", true);
+        return promise.then(function (obj: any) {
+            expect(obj).to.equal("Hello");
+            expect(component.cancelOnProps[0]).to.equal(promise);
+        });
+    });
+});
+
+class CancelableObj implements Cancelable {
+    constructor() {
+        this.cancel = sinon.stub();
+    }
+
+    reset() {
+        this.cancel.reset();
+    }
+
+    cancel: Sinon.SinonStub;
+}

--- a/src/components/CancelableComponent.test.tsx
+++ b/src/components/CancelableComponent.test.tsx
@@ -91,8 +91,6 @@ describe("CancelableComponent", function () {
 
     it("Tests that the cancelable is removed when the promise is finished with normal cancelables.", function () {
         const component = wrapper.instance() as CancelableComponent<any, any>;
-
-        console.info("RESOLVING");
         const promise = component.resolve("Hello");
         return promise.then(function (obj: any) {
             expect(component.cancelables).to.have.length(0);

--- a/src/components/CancelableComponent.test.tsx
+++ b/src/components/CancelableComponent.test.tsx
@@ -1,3 +1,4 @@
+import * as Bluebird from "bluebird";
 import * as chai from "chai";
 import { shallow, ShallowWrapper } from "enzyme";
 import * as React from "react";
@@ -108,10 +109,10 @@ describe("CancelableComponent", function () {
 
     it("Tests that the cancelable is removed from the middle of the stack when finished.", function () {
         const component = wrapper.instance() as CancelableComponent<any, any>;
-        component.resolve("Hello", true);
-        component.resolve("Hello", true);
+        component.resolve(delayPromise(1000, "Hello"));
+        component.resolve(delayPromise(1000, "Hello"));
         const promise2 = component.resolve("Hello", true);
-        component.resolve("Hello", true);
+        component.resolve(delayPromise(1000, "Hello"));
 
         return promise2.then(function () {
             for (let c of component.cancelables) {
@@ -120,6 +121,7 @@ describe("CancelableComponent", function () {
             for (let c of component.cancelOnProps) {
                 expect(c).to.not.equal(promise2);
             }
+            component.componentWillUnmount(); // Cancels the rest.
         });
     });
 });
@@ -134,4 +136,8 @@ class CancelableObj implements Cancelable {
     }
 
     cancel: Sinon.SinonStub;
+}
+
+function delayPromise(ms: number, returnObj: any): Promise<any> {
+    return Bluebird.delay(ms, returnObj);
 }

--- a/src/components/CancelableComponent.tsx
+++ b/src/components/CancelableComponent.tsx
@@ -60,7 +60,7 @@ export class CancelableComponent<P extends PromiseComponentProps, S extends Prom
         this.cancelOnProps = [];
     }
 
-    resolve<T>(obj: T, cancelOnPropsChange?: boolean): Thenable<T> {
+    resolve<T>(obj: T | Thenable<T>, cancelOnPropsChange?: boolean): Thenable<T> {
         const newPromise = Bluebird.resolve(obj);
         this.registerCancelable(newPromise, cancelOnPropsChange);
         return newPromise;

--- a/src/components/CancelableComponent.tsx
+++ b/src/components/CancelableComponent.tsx
@@ -60,7 +60,7 @@ export class CancelableComponent<P extends PromiseComponentProps, S extends Prom
         this.cancelOnProps = [];
     }
 
-    resolve<T>(obj: T | Thenable<T>, cancelOnPropsChange?: boolean): Thenable<T> {
+    resolve<T>(obj: T | Thenable<T>, cancelOnPropsChange?: boolean): Promise<T> {
         const newPromise = Bluebird.resolve(obj);
         this.registerCancelable(newPromise, cancelOnPropsChange);
         return newPromise;

--- a/src/components/CancelableComponent.tsx
+++ b/src/components/CancelableComponent.tsx
@@ -63,7 +63,9 @@ export class CancelableComponent<P extends PromiseComponentProps, S extends Prom
     resolve<T>(obj: T | Thenable<T>, cancelOnPropsChange?: boolean): Promise<T> {
         const newPromise = Bluebird.resolve(obj);
         this.registerCancelable(newPromise, cancelOnPropsChange);
-        return newPromise;
+        return newPromise.finally(() => {
+            this.unregisterCancelable(newPromise, cancelOnPropsChange);
+        });
     }
 
     /**
@@ -78,6 +80,18 @@ export class CancelableComponent<P extends PromiseComponentProps, S extends Prom
         } else {
             this.cancelables.push(c);
         }
+    }
+
+    unregisterCancelable(c: Cancelable, cancelOnPropsChange: boolean = false) {
+        const arr = (cancelOnPropsChange) ? this.cancelOnProps : this.cancelables;
+        let index = 0;
+        for (let obj of arr) {
+            if (c === obj) {
+                break;
+            }
+            ++index;
+        }
+        arr.splice(index, 1);
     }
 
     render() {

--- a/src/components/CancelableComponent.tsx
+++ b/src/components/CancelableComponent.tsx
@@ -1,0 +1,86 @@
+import * as Bluebird from "bluebird";
+import * as React from "react";
+
+Bluebird.config({
+    cancellation: true
+});
+
+export interface Cancelable {
+    cancel: () => void;
+}
+
+export interface PromiseComponentProps {
+
+}
+
+export interface PromiseComponentState {
+
+}
+
+/**
+ * A component that will automatically cancel Promises that were issued. All cancelables must be created through the methods of
+ * this class or sent to `registerCancelable`
+ */
+export class CancelableComponent<P extends PromiseComponentProps, S extends PromiseComponentState> extends React.Component<P, S> {
+
+    cancelables: Cancelable[];
+    cancelOnProps: Cancelable[];
+
+    constructor(props: P) {
+        super(props);
+
+        this.cancelables = [];
+        this.cancelOnProps = [];
+
+        this.resolve = this.resolve.bind(this);
+        this.registerCancelable = this.registerCancelable.bind(this);
+    }
+
+    /**
+     * Child classes must call super.
+     */
+    componentWillReceiveProps(nextProps: P, context: any) {
+        for (let c of this.cancelOnProps) {
+            c.cancel();
+        }
+        this.cancelOnProps = [];
+    }
+
+    /**
+     * Child classes much call super.
+     */
+    componentWillUnmount() {
+        for (let c of this.cancelables) {
+            c.cancel();
+        }
+        for (let c of this.cancelOnProps) {
+            c.cancel();
+        }
+        this.cancelables = [];
+        this.cancelOnProps = [];
+    }
+
+    resolve<T>(obj: T, cancelOnPropsChange?: boolean): Thenable<T> {
+        const newPromise = Bluebird.resolve(obj);
+        this.registerCancelable(newPromise, cancelOnPropsChange);
+        return newPromise;
+    }
+
+    /**
+     * Registers a Cancelable object to automatically be canceled on unmount.
+     * @param c The cancelable to register.
+     * @param cancelOnPropsChange True if the cancelable should be canceled on `onComponentWillChangeProps` as well. It will still
+     * be canceled on unmount as well if the component's props were not updated.
+     */
+    registerCancelable(c: Cancelable, cancelOnPropsChange: boolean = false) {
+        if (cancelOnPropsChange) {
+            this.cancelOnProps.push(c);
+        } else {
+            this.cancelables.push(c);
+        }
+    }
+
+    render() {
+        return (<div />);
+    }
+}

--- a/src/components/LoadingComponent.test.tsx
+++ b/src/components/LoadingComponent.test.tsx
@@ -185,17 +185,13 @@ describe("LoadingComponent", function () {
             cancelSpy = sinon.spy(LoadingComponent.prototype, "cancel");
             startLoadingStub = sinon.stub(LoadingComponent.prototype, "startLoading", function () {
                 return new Promise((resolve, reject) => {
-                    console.info("LOADING");
                     while (runLoad);
-                    console.info("LOADED");
                     resolve(loadedData);
                 });
             });
             mapStub = sinon.stub(LoadingComponent.prototype, "map", function () {
                 return new Promise((resolve, reject) => {
-                    console.info("MAPPING");
                     while (runMap);
-                    console.info("MAPPED");
                     resolve(mappedData);
                 });
             });
@@ -238,9 +234,7 @@ describe("LoadingComponent", function () {
 
             it("Tests cancel will stop the operation.", function () {
                 // if it gets stuck in the stub, then it'll cancel out and skip the map because data was never returned.
-                console.info("Stopping load.");
                 stopLoad();
-                console.info("Canceling");
                 instance.cancel();
                 return currentLoadingPromise
                     .finally(function () {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -68,7 +68,7 @@ Firebase.auth().onAuthStateChanged(function (user: Firebase.User) {
     const lastUser = store.getState().session.user;
     // If there is a user, set it
     if (user) {
-        if (!lastUser || lastUser.email !== user.email) {
+        if (!lastUser || lastUser.userId !== user.uid) {
             store.dispatch(setUser(new FirebaseUser(user)));
             if (!lastUser) {
                 store.dispatch(replace("/#welcome"));

--- a/src/models/spoke.ts
+++ b/src/models/spoke.ts
@@ -1,0 +1,35 @@
+export type PIPE_TYPE = "HTTP" | "LAMBDA";
+
+export interface Spoke {
+    /**
+     * Secret key of the skill.
+     */
+    uuid: string;
+    /**
+     * A unique diagnostic key for the skill. Currently the same as the secret key.
+     */
+    diagnosticKey: string;
+    /**
+     * The location that the skill would be retrieved from.
+     */
+    endPoint: {
+        /**
+         * Skill ID.
+         */
+        name: string;
+    };
+    /**
+     * Location to the pipe.
+     */
+    path: string;
+    /**
+     * Type of pipe this is.
+     */
+    pipeType: PIPE_TYPE;
+    /**
+     * True or false based on whether live debugging is enabled.
+     */
+    proxy: boolean;
+}
+
+export default Spoke;

--- a/src/models/spoke.ts
+++ b/src/models/spoke.ts
@@ -18,6 +18,14 @@ export interface Spoke {
          */
         name: string;
     };
+    http?: {
+        url: string;
+    };
+    lambda?: {
+        lambdaARN: string;
+        awsAccessKey: string;
+        awsSecretKey: string;
+    };
     /**
      * Location to the pipe.
      */

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,19 +1,20 @@
 
 export interface UserProperties {
   readonly email: string;
+  readonly userId?: string;
   readonly displayName?: string;
   readonly photoUrl?: string;
 }
 
 export default class User implements UserProperties {
 
+  readonly userId: string;
   readonly email: string;
-
   readonly displayName?: string;
-
   readonly photoUrl?: string;
 
   constructor(props: UserProperties) {
+    this.userId = props.userId;
     this.email = props.email;
     this.displayName = props.displayName;
     this.photoUrl = props.photoUrl;
@@ -25,6 +26,6 @@ import * as Firebase from "firebase";
 export class FirebaseUser extends User {
 
   constructor(user: Firebase.UserInfo) {
-    super({email: user.email, displayName: user.displayName, photoUrl: user.photoURL});
+    super({ userId: user.uid, email: user.email, displayName: user.displayName, photoUrl: user.photoURL});
   }
 }

--- a/src/pages/NewSourcePage.test.tsx
+++ b/src/pages/NewSourcePage.test.tsx
@@ -187,7 +187,11 @@ describe("New Source Page", function () {
         let invalidChars = "!@#$%^&*()_+={}[];:'\"<,>.?/|\\~`";
 
         before(function () {
-            nameRule = new SourceNameRule;
+            nameRule = new SourceNameRule();
+        });
+
+        it("Tests that the name rule error message exists.", function() {
+            expect(nameRule.errorMessage).to.exist;
         });
 
         it("Tests the \"At leat 3 rule\"", function () {

--- a/src/pages/NewSourcePage.tsx
+++ b/src/pages/NewSourcePage.tsx
@@ -155,7 +155,6 @@ interface CodeFormProps {
 }
 
 interface CodeFormState {
-    secretKey: string;
 }
 
 class CodeForm extends React.Component<CodeFormProps, CodeFormState> {
@@ -166,35 +165,11 @@ class CodeForm extends React.Component<CodeFormProps, CodeFormState> {
         this.goToLogs = this.goToLogs.bind(this);
 
         this.state = {
-            secretKey: CodeForm.codeSecretKey(props.source)
         };
-    }
-
-    componentWillReceiveProps(nextProps: CodeFormProps, context: any) {
-        this.setState({
-            ...this.state, ...{
-                secretKey: CodeForm.codeSecretKey(nextProps.source)
-            }
-        });
     }
 
     goToLogs() {
         this.props.onGoToLogs(this.props.source);
-    }
-
-    codeStyle(): React.CSSProperties {
-        return {
-            margin: "10px",
-            padding: "20px",
-            backgroundColor: "#CFD8DC",
-            color: "#263238",
-            whiteSpace: "pre-line"
-        };
-    }
-
-    static codeSecretKey(source: Source | undefined): string {
-        let defaultKey = "/* secret key */";
-        return (source !== undefined && source.secretKey !== undefined) ? source.secretKey : defaultKey;
     }
 
     render(): JSX.Element {

--- a/src/pages/NewSourcePage.tsx
+++ b/src/pages/NewSourcePage.tsx
@@ -199,10 +199,10 @@ class CodeForm extends React.Component<CodeFormProps, CodeFormState> {
 
     render(): JSX.Element {
         const hasKey = this.props.source !== undefined;
-        const key = (hasKey) ? this.props.source.secretKey : undefined;
+        const { onGoBack, source } = this.props;
         return (
             <div>
-                <IntegrationPage showSecret={true} secretKey={key} />
+                <IntegrationPage showSecret={true} source={source} />
                 {
                     (hasKey) ?
                         (
@@ -211,7 +211,7 @@ class CodeForm extends React.Component<CodeFormProps, CodeFormState> {
                                     <Button accent={true} raised={true} onClick={this.goToLogs}>Next: Check for Logs</Button>
                                 </Cell>
                                 <Cell col={12}>
-                                    <Button raised={true} onClick={this.props.onGoBack}>Create Another</Button>
+                                    <Button raised={true} onClick={onGoBack}>Create Another</Button>
                                 </Cell>
                             </Grid>
                         )

--- a/src/pages/integration/IntegrationHttp.test.tsx
+++ b/src/pages/integration/IntegrationHttp.test.tsx
@@ -1,0 +1,46 @@
+import * as chai from "chai";
+import { shallow, ShallowWrapper } from "enzyme";
+import * as React from "react";
+import * as sinon from "sinon";
+import * as sinonChai from "sinon-chai";
+
+import Input from "react-toolbox/lib/input";
+
+import IntegrationHttp from "./IntegrationHttp";
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe("IntegrationHttp", function() {
+    describe("Renders", function() {
+        let wrapper: ShallowWrapper<any, any>;
+        let onChange: Sinon.SinonStub;
+
+        before(function() {
+            onChange = sinon.stub();
+            wrapper = shallow(<IntegrationHttp
+                url={"TestUrl"}
+                onUrlChange={onChange} />);
+        });
+
+        afterEach(function() {
+            onChange.reset();
+        });
+
+        it("Tests the URL/ARN input exists.", function() {
+            expect(wrapper.find(Input)).to.have.length(1);
+        });
+
+        it("Tests the value of the url is passed to the input.", function() {
+            const inputWrapper = wrapper.find(Input).at(0);
+            expect(inputWrapper).to.have.prop("value", "TestUrl");
+        });
+
+        it("Tests the onUrlChange method is called with the new value.", function() {
+            const inputWrapper = wrapper.find(Input).at(0);
+            inputWrapper.simulate("change", "New URL");
+            expect(onChange).to.have.been.calledOnce;
+            expect(onChange).to.have.been.calledWith("New URL");
+        });
+    });
+});

--- a/src/pages/integration/IntegrationHttp.test.tsx
+++ b/src/pages/integration/IntegrationHttp.test.tsx
@@ -19,6 +19,7 @@ describe("IntegrationHttp", function() {
         before(function() {
             onChange = sinon.stub();
             wrapper = shallow(<IntegrationHttp
+                theme={"TestTheme"}
                 url={"TestUrl"}
                 onUrlChange={onChange} />);
         });
@@ -34,6 +35,7 @@ describe("IntegrationHttp", function() {
         it("Tests the value of the url is passed to the input.", function() {
             const inputWrapper = wrapper.find(Input).at(0);
             expect(inputWrapper).to.have.prop("value", "TestUrl");
+            expect(inputWrapper).to.have.prop("theme", "TestTheme");
         });
 
         it("Tests the onUrlChange method is called with the new value.", function() {

--- a/src/pages/integration/IntegrationHttp.tsx
+++ b/src/pages/integration/IntegrationHttp.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import Input from "react-toolbox/lib/input";
 
 interface HttpProps {
+    theme?: string;
     url?: string;
     onUrlChange?: (newUrl: string) => void;
 }
@@ -17,8 +18,8 @@ export class IntegrationHttp extends React.Component<HttpProps, HttpState> {
     };
 
     render() {
-        const { url, onUrlChange } = this.props;
-        return (<Input label={"URL"} value={url} onChange={onUrlChange} />);
+        const { url, onUrlChange, ...others } = this.props;
+        return (<Input {...others} label={"URL"} value={url} onChange={onUrlChange} />);
     }
 }
 

--- a/src/pages/integration/IntegrationHttp.tsx
+++ b/src/pages/integration/IntegrationHttp.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+
+import Input from "react-toolbox/lib/input";
+
+interface HttpProps {
+    url?: string;
+    onUrlChange?: (newUrl: string) => void;
+}
+
+interface HttpState {
+
+}
+
+export class IntegrationHttp extends React.Component<HttpProps, HttpState> {
+    static defaultProps: HttpProps = {
+        url: ""
+    };
+
+    render() {
+        const { url, onUrlChange } = this.props;
+        return (<Input label={"URL"} value={url} onChange={onUrlChange} />);
+    }
+}
+
+export default IntegrationHttp;

--- a/src/pages/integration/IntegrationLambda.test.tsx
+++ b/src/pages/integration/IntegrationLambda.test.tsx
@@ -20,9 +20,9 @@ describe("IntegrationLambda", function() {
             onChange = sinon.stub();
             wrapper = shallow(<IntegrationLambda
                 theme={"TestTheme"}
-                arn={"TestArn"}
-                iamAccessKey={"TestAccessKey"}
-                iamSecretKey={"TestSecretKey"}
+                lambdaARN={"TestArn"}
+                awsAccessKey={"TestAccessKey"}
+                awsSecretKey={"TestSecretKey"}
                 onChange={onChange} />);
         });
 
@@ -46,7 +46,7 @@ describe("IntegrationLambda", function() {
         });
 
         it("Tests the onUrlChange method is called with the new value.", function() {
-            testInputChange(0, "Value", "arn", "Value");
+            testInputChange(0, "Value", "lambdaARN", "Value");
         });
 
         it("Tests the value of the Access key is passed to the Access Key input.", function() {
@@ -54,7 +54,7 @@ describe("IntegrationLambda", function() {
         });
 
         it("Tests the onUrlChange method is called with the new value.", function() {
-            testInputChange(1, "New Value", "iamAccessKey", "New Value");
+            testInputChange(1, "New Value", "awsAccessKey", "New Value");
         });
 
         it("Tests the value of the Secret Key is passed to the Access Key input.", function() {
@@ -62,7 +62,7 @@ describe("IntegrationLambda", function() {
         });
 
         it("Tests the onUrlChange method is called with the new value.", function() {
-            testInputChange(2, "New Value", "iamSecretKey", "New Value");
+            testInputChange(2, "New Value", "awsSecretKey", "New Value");
         });
 
         function testInputValue(index: number, expectedValue: string) {

--- a/src/pages/integration/IntegrationLambda.test.tsx
+++ b/src/pages/integration/IntegrationLambda.test.tsx
@@ -1,0 +1,76 @@
+import * as chai from "chai";
+import { shallow, ShallowWrapper } from "enzyme";
+import * as React from "react";
+import * as sinon from "sinon";
+import * as sinonChai from "sinon-chai";
+
+import Input from "react-toolbox/lib/input";
+
+import IntegrationLambda from "./IntegrationLambda";
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe("IntegrationLambda", function() {
+    describe("Renders", function() {
+        let wrapper: ShallowWrapper<any, any>;
+        let onChange: Sinon.SinonStub;
+
+        before(function() {
+            onChange = sinon.stub();
+            wrapper = shallow(<IntegrationLambda
+                arn={"TestArn"}
+                iamAccesskey={"TestAccessKey"}
+                iamSecretKey={"TestSecretKey"}
+                onChange={onChange} />);
+        });
+
+        afterEach(function() {
+            onChange.reset();
+        });
+
+        it("Tests the ARN and KEY inputs exist..", function() {
+            const inputs = wrapper.find(Input);
+            expect(inputs).to.have.length(3);
+            expect(inputs.at(0)).to.have.prop("label", "Lambda ARN");
+            expect(inputs.at(1)).to.have.prop("label", "IAM Access Key");
+            expect(inputs.at(2)).to.have.prop("label", "IAM Secret Key");
+        });
+
+        it("Tests the value of the ARN is passed to the ARN input.", function() {
+            testInputValue(0, "TestArn");
+        });
+
+        it("Tests the onUrlChange method is called with the new value.", function() {
+            testInputChange(0, "Value", "arn", "Value");
+        });
+
+        it("Tests the value of the Access key is passed to the Access Key input.", function() {
+            testInputValue(1, "TestAccessKey");
+        });
+
+        it("Tests the onUrlChange method is called with the new value.", function() {
+            testInputChange(1, "New Value", "iamAccessKey", "New Value");
+        });
+
+        it("Tests the value of the Secret Key is passed to the Access Key input.", function() {
+            testInputValue(2, "TestSecretKey");
+        });
+
+        it("Tests the onUrlChange method is called with the new value.", function() {
+            testInputChange(2, "New Value", "iamSecretKey", "New Value");
+        });
+
+        function testInputValue(index: number, expectedValue: string) {
+            const inputWrapper = wrapper.find(Input).at(index);
+            expect(inputWrapper).to.have.prop("value", expectedValue);
+        }
+
+        function testInputChange(index: number, changeTo: string, firstArg: string, secondArg: string) {
+            const inputWrapper = wrapper.find(Input).at(index);
+            inputWrapper.simulate("change", changeTo);
+            expect(onChange).to.have.been.calledOnce;
+            expect(onChange).to.have.been.calledWith(firstArg, secondArg);
+        }
+    });
+});

--- a/src/pages/integration/IntegrationLambda.test.tsx
+++ b/src/pages/integration/IntegrationLambda.test.tsx
@@ -34,8 +34,11 @@ describe("IntegrationLambda", function() {
             const inputs = wrapper.find(Input);
             expect(inputs).to.have.length(3);
             expect(inputs.at(0)).to.have.prop("label", "Lambda ARN");
+            expect(inputs.at(0)).to.have.prop("theme", "TestTheme");
             expect(inputs.at(1)).to.have.prop("label", "IAM Access Key");
+            expect(inputs.at(1)).to.have.prop("theme", "TestTheme");
             expect(inputs.at(2)).to.have.prop("label", "IAM Secret Key");
+            expect(inputs.at(2)).to.have.prop("theme", "TestTheme");
         });
 
         it("Tests the value of the ARN is passed to the ARN input.", function() {

--- a/src/pages/integration/IntegrationLambda.test.tsx
+++ b/src/pages/integration/IntegrationLambda.test.tsx
@@ -20,7 +20,7 @@ describe("IntegrationLambda", function() {
             onChange = sinon.stub();
             wrapper = shallow(<IntegrationLambda
                 arn={"TestArn"}
-                iamAccesskey={"TestAccessKey"}
+                iamAccessKey={"TestAccessKey"}
                 iamSecretKey={"TestSecretKey"}
                 onChange={onChange} />);
         });

--- a/src/pages/integration/IntegrationLambda.test.tsx
+++ b/src/pages/integration/IntegrationLambda.test.tsx
@@ -19,6 +19,7 @@ describe("IntegrationLambda", function() {
         before(function() {
             onChange = sinon.stub();
             wrapper = shallow(<IntegrationLambda
+                theme={"TestTheme"}
                 arn={"TestArn"}
                 iamAccessKey={"TestAccessKey"}
                 iamSecretKey={"TestSecretKey"}

--- a/src/pages/integration/IntegrationLambda.tsx
+++ b/src/pages/integration/IntegrationLambda.tsx
@@ -4,7 +4,7 @@ import Input from "react-toolbox/lib/input";
 
 interface LambdaProps {
     arn?: string;
-    iamAccesskey?: string;
+    iamAccessKey?: string;
     iamSecretKey?: string;
     onChange?: (type: "arn" | "iamAccessKey" | "iamSecretKey", newValue: string) => void;
 
@@ -18,7 +18,7 @@ export class IntegrationLambda extends React.Component<LambdaProps, LambdaState>
 
     static defaultProps: LambdaProps = {
         arn: "",
-        iamAccesskey: "",
+        iamAccessKey: "",
         iamSecretKey: ""
     };
 
@@ -30,9 +30,9 @@ export class IntegrationLambda extends React.Component<LambdaProps, LambdaState>
         this.handleIamSecretKeyChange = this.handleChange.bind(this, "iamSecretKey");
     }
 
-    handleArnChange: (type: string, newValue: string) => void;
-    handleIamAccessKeyChange: (type: string, newValue: string) => void;
-    handleIamSecretKeyChange: (type: string, newValue: string) => void;
+    handleArnChange: (type: "arn", newValue: string) => void;
+    handleIamAccessKeyChange: (type: "iamAccessKey", newValue: string) => void;
+    handleIamSecretKeyChange: (type: "iamSecretKey", newValue: string) => void;
     handleChange(type: "arn" | "iamAccessKey" | "iamSecretKey", newValue: string) {
         const { onChange } = this.props;
         if (onChange) {

--- a/src/pages/integration/IntegrationLambda.tsx
+++ b/src/pages/integration/IntegrationLambda.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import Input from "react-toolbox/lib/input";
 
 interface LambdaProps {
+    theme?: string;
     arn?: string;
     iamAccessKey?: string;
     iamSecretKey?: string;
@@ -41,18 +42,21 @@ export class IntegrationLambda extends React.Component<LambdaProps, LambdaState>
     }
 
     render() {
-        const { arn, iamAccessKey, iamSecretKey } = this.props;
+        const { arn, iamAccessKey, iamSecretKey, ...others } = this.props;
         return (
             <div>
                 <Input
+                    {...others}
                     label={"Lambda ARN"}
                     value={arn}
                     onChange={this.handleArnChange} />
                 <Input
+                    {...others}
                     label={"IAM Access Key"}
                     value={iamAccessKey}
                     onChange={this.handleIamAccessKeyChange} />
                 <Input
+                    {...others}
                     label={"IAM Secret Key"}
                     value={iamSecretKey}
                     onChange={this.handleIamSecretKeyChange} />

--- a/src/pages/integration/IntegrationLambda.tsx
+++ b/src/pages/integration/IntegrationLambda.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+
+import Input from "react-toolbox/lib/input";
+
+interface LambdaProps {
+    arn?: string;
+    iamAccesskey?: string;
+    iamSecretKey?: string;
+    onChange?: (type: "arn" | "iamAccessKey" | "iamSecretKey", newValue: string) => void;
+
+}
+
+interface LambdaState {
+
+}
+
+export class IntegrationLambda extends React.Component<LambdaProps, LambdaState> {
+
+    static defaultProps: LambdaProps = {
+        arn: "",
+        iamAccesskey: "",
+        iamSecretKey: ""
+    };
+
+    constructor(props: LambdaProps) {
+        super(props);
+    }
+
+    handleChange(type: "arn" | "iamAccessKey" | "iamSecretKey", newValue: string) {
+        const { onChange } = this.props;
+        if (onChange) {
+            console.info("type " + type + " value = " + newValue);
+            onChange(type, newValue);
+        }
+    }
+
+    render() {
+        const { arn, iamAccesskey, iamSecretKey } = this.props;
+        return (
+            <div>
+                <Input
+                    label={"Lambda ARN"}
+                    value={arn}
+                    onChange={this.handleChange.bind(this, "arn")} />
+                <Input
+                    label={"IAM Access Key"}
+                    value={iamAccesskey}
+                    onChange={this.handleChange.bind(this, "iamAccessKey")} />
+                <Input
+                    label={"IAM Secret Key"}
+                    value={iamSecretKey}
+                    onChange={this.handleChange.bind(this, "iamSecretKey")} />
+            </div>);
+    }
+}
+
+export default IntegrationLambda;

--- a/src/pages/integration/IntegrationLambda.tsx
+++ b/src/pages/integration/IntegrationLambda.tsx
@@ -4,10 +4,10 @@ import Input from "react-toolbox/lib/input";
 
 interface LambdaProps {
     theme?: string;
-    arn?: string;
-    iamAccessKey?: string;
-    iamSecretKey?: string;
-    onChange?: (type: "arn" | "iamAccessKey" | "iamSecretKey", newValue: string) => void;
+    lambdaARN?: string;
+    awsAccessKey?: string;
+    awsSecretKey?: string;
+    onChange?: (type: "lambdaARN" | "awsAccessKey" | "awsSecretKey", newValue: string) => void;
 
 }
 
@@ -18,23 +18,23 @@ interface LambdaState {
 export class IntegrationLambda extends React.Component<LambdaProps, LambdaState> {
 
     static defaultProps: LambdaProps = {
-        arn: "",
-        iamAccessKey: "",
-        iamSecretKey: ""
+        lambdaARN: "",
+        awsAccessKey: "",
+        awsSecretKey: ""
     };
 
     constructor(props: LambdaProps) {
         super(props);
 
-        this.handleArnChange = this.handleChange.bind(this, "arn");
-        this.handleIamAccessKeyChange = this.handleChange.bind(this, "iamAccessKey");
-        this.handleIamSecretKeyChange = this.handleChange.bind(this, "iamSecretKey");
+        this.handleArnChange = this.handleChange.bind(this, "lambdaARN");
+        this.handleIamAccessKeyChange = this.handleChange.bind(this, "awsAccessKey");
+        this.handleIamSecretKeyChange = this.handleChange.bind(this, "awsSecretKey");
     }
 
-    handleArnChange: (type: "arn", newValue: string) => void;
-    handleIamAccessKeyChange: (type: "iamAccessKey", newValue: string) => void;
-    handleIamSecretKeyChange: (type: "iamSecretKey", newValue: string) => void;
-    handleChange(type: "arn" | "iamAccessKey" | "iamSecretKey", newValue: string) {
+    handleArnChange: (type: "lambdaARN", newValue: string) => void;
+    handleIamAccessKeyChange: (type: "awsAccessKey", newValue: string) => void;
+    handleIamSecretKeyChange: (type: "awsSecretKey", newValue: string) => void;
+    handleChange(type: "lambdaARN" | "awsAccessKey" | "awsSecretKey", newValue: string) {
         const { onChange } = this.props;
         if (onChange) {
             onChange(type, newValue);
@@ -42,23 +42,23 @@ export class IntegrationLambda extends React.Component<LambdaProps, LambdaState>
     }
 
     render() {
-        const { arn, iamAccessKey, iamSecretKey, ...others } = this.props;
+        const { lambdaARN, awsAccessKey, awsSecretKey, ...others } = this.props;
         return (
             <div>
                 <Input
                     {...others}
                     label={"Lambda ARN"}
-                    value={arn}
+                    value={lambdaARN}
                     onChange={this.handleArnChange} />
                 <Input
                     {...others}
                     label={"IAM Access Key"}
-                    value={iamAccessKey}
+                    value={awsAccessKey}
                     onChange={this.handleIamAccessKeyChange} />
                 <Input
                     {...others}
                     label={"IAM Secret Key"}
-                    value={iamSecretKey}
+                    value={awsSecretKey}
                     onChange={this.handleIamSecretKeyChange} />
             </div>);
     }

--- a/src/pages/integration/IntegrationLambda.tsx
+++ b/src/pages/integration/IntegrationLambda.tsx
@@ -24,12 +24,18 @@ export class IntegrationLambda extends React.Component<LambdaProps, LambdaState>
 
     constructor(props: LambdaProps) {
         super(props);
+
+        this.handleArnChange = this.handleChange.bind(this, "arn");
+        this.handleIamAccessKeyChange = this.handleChange.bind(this, "iamAccessKey");
+        this.handleIamSecretKeyChange = this.handleChange.bind(this, "iamSecretKey");
     }
 
+    handleArnChange: (type: string, newValue: string) => void;
+    handleIamAccessKeyChange: (type: string, newValue: string) => void;
+    handleIamSecretKeyChange: (type: string, newValue: string) => void;
     handleChange(type: "arn" | "iamAccessKey" | "iamSecretKey", newValue: string) {
         const { onChange } = this.props;
         if (onChange) {
-            console.info("type " + type + " value = " + newValue);
             onChange(type, newValue);
         }
     }
@@ -41,15 +47,15 @@ export class IntegrationLambda extends React.Component<LambdaProps, LambdaState>
                 <Input
                     label={"Lambda ARN"}
                     value={arn}
-                    onChange={this.handleChange.bind(this, "arn")} />
+                    onChange={this.handleArnChange} />
                 <Input
                     label={"IAM Access Key"}
                     value={iamAccesskey}
-                    onChange={this.handleChange.bind(this, "iamAccessKey")} />
+                    onChange={this.handleIamAccessKeyChange} />
                 <Input
                     label={"IAM Secret Key"}
                     value={iamSecretKey}
-                    onChange={this.handleChange.bind(this, "iamSecretKey")} />
+                    onChange={this.handleIamSecretKeyChange} />
             </div>);
     }
 }

--- a/src/pages/integration/IntegrationLambda.tsx
+++ b/src/pages/integration/IntegrationLambda.tsx
@@ -41,7 +41,7 @@ export class IntegrationLambda extends React.Component<LambdaProps, LambdaState>
     }
 
     render() {
-        const { arn, iamAccesskey, iamSecretKey } = this.props;
+        const { arn, iamAccessKey, iamSecretKey } = this.props;
         return (
             <div>
                 <Input
@@ -50,7 +50,7 @@ export class IntegrationLambda extends React.Component<LambdaProps, LambdaState>
                     onChange={this.handleArnChange} />
                 <Input
                     label={"IAM Access Key"}
-                    value={iamAccesskey}
+                    value={iamAccessKey}
                     onChange={this.handleIamAccessKeyChange} />
                 <Input
                     label={"IAM Secret Key"}

--- a/src/pages/integration/IntegrationPage.test.tsx
+++ b/src/pages/integration/IntegrationPage.test.tsx
@@ -34,8 +34,14 @@ describe("IntegrationPage", function () {
             expect(wrapper.find(Tabs).at(0).prop("index")).to.equal(0);
         });
 
-        it("Tests the first tab is IntegrationNodeJS and gets the secret key.", function () {
+        it("Tests the Spoke Page exists", function () {
             const tab = wrapper.find(Tab).at(0);
+            const tabPage = tab.find(IntegrationSpokes);
+            expect(tabPage).to.have.length(1);
+        });
+
+        it("Tests the first tab is IntegrationNodeJS and gets the secret key.", function () {
+            const tab = wrapper.find(Tab).at(1);
             const tabPage = tab.find(IntegrationNodeJS); // TODO: I'm not sure why this doesn't work.
             // const tabPage = tab.childAt(0);
             expect(tabPage).to.have.length(1);
@@ -43,23 +49,17 @@ describe("IntegrationPage", function () {
         });
 
         it("Tests the second tab is IntegrationExpressJS and gets the secret key.", function () {
-            const tab = wrapper.find(Tab).at(1);
+            const tab = wrapper.find(Tab).at(2);
             const tabPage = tab.find(IntegrationExpressJS);
             expect(tabPage).to.have.length(1);
             expect(tabPage.prop("secretKey")).to.equal(source.secretKey);
         });
 
         it("Tests the third tab is IntegrationJava and gets the secret key.", function () {
-            const tab = wrapper.find(Tab).at(2);
+            const tab = wrapper.find(Tab).at(3);
             const tabPage = tab.find(IntegrationJava);
             expect(tabPage).to.have.length(1);
             expect(tabPage.prop("secretKey")).to.equal(source.secretKey);
-        });
-
-        it("Tests the Spoke Page exists", function () {
-            const tab = wrapper.find(Tab).at(3);
-            const tabPage = tab.find(IntegrationSpokes);
-            expect(tabPage).to.have.length(1);
         });
     });
 
@@ -70,33 +70,32 @@ describe("IntegrationPage", function () {
             wrapper = shallow(<IntegrationPage source={undefined} />);
         });
 
-        it("Tests the first tab is IntegrationNodeJS and gets the secret key.", function () {
+        it("Tests the Spoke Page exists", function () {
             const tab = wrapper.find(Tab).at(0);
-            const tabPage = tab.find(IntegrationNodeJS); // TODO: I'm not sure why this doesn't work.
-            // const tabPage = tab.childAt(0);
+            const tabPage = tab.find(IntegrationSpokes);
+            expect(tabPage).to.have.length(1);
+            expect(tabPage.prop("source")).to.be.undefined;
+        });
+
+        it("Tests the first tab is IntegrationNodeJS and gets the secret key.", function () {
+            const tab = wrapper.find(Tab).at(1);
+            const tabPage = tab.find(IntegrationNodeJS);
             expect(tabPage).to.have.length(1);
             expect(tabPage.prop("secretKey")).to.be.undefined;
         });
 
         it("Tests the second tab is IntegrationExpressJS and gets the secret key.", function () {
-            const tab = wrapper.find(Tab).at(1);
+            const tab = wrapper.find(Tab).at(2);
             const tabPage = tab.find(IntegrationExpressJS);
             expect(tabPage).to.have.length(1);
             expect(tabPage.prop("secretKey")).to.be.undefined;
         });
 
         it("Tests the third tab is IntegrationJava and gets the secret key.", function () {
-            const tab = wrapper.find(Tab).at(2);
+            const tab = wrapper.find(Tab).at(3);
             const tabPage = tab.find(IntegrationJava);
             expect(tabPage).to.have.length(1);
             expect(tabPage.prop("secretKey")).to.be.undefined;
-        });
-
-        it("Tests the Spoke Page exists", function () {
-            const tab = wrapper.find(Tab).at(3);
-            const tabPage = tab.find(IntegrationSpokes);
-            expect(tabPage).to.have.length(1);
-            expect(tabPage.prop("source")).to.be.undefined;
         });
     });
 

--- a/src/pages/integration/IntegrationPage.test.tsx
+++ b/src/pages/integration/IntegrationPage.test.tsx
@@ -8,6 +8,7 @@ import IntegrationExpressJS from "./IntegrationExpressJS";
 import IntegrationJava from "./IntegrationJava";
 import IntegrationNodeJS from "./IntegrationNodeJSLambda";
 import IntegrationPage from "./IntegrationPage";
+import IntegrationSpokes from "./IntegrationSpokes";
 
 const expect = chai.expect;
 
@@ -22,7 +23,7 @@ describe("IntegrationPage", function () {
 
         it ("Tests there are the appropriate number of tabs.", function() {
             expect(wrapper.find(Tabs)).to.have.length(1);
-            expect(wrapper.find(Tab)).to.have.length(3);
+            expect(wrapper.find(Tab)).to.have.length(4);
         });
 
         it ("Tests the Tabs property has the default index.", function() {
@@ -49,6 +50,12 @@ describe("IntegrationPage", function () {
             const tabPage = tab.find(IntegrationJava);
             expect(tabPage).to.have.length(1);
             expect(tabPage.prop("secretKey")).to.equal("ABCD123");
+        });
+
+        it("Tests the Spoke Page exists", function() {
+            const tab = wrapper.find(Tab).at(3);
+            const tabPage = tab.find(IntegrationSpokes);
+            expect(tabPage).to.have.length(1);
         });
     });
 

--- a/src/pages/integration/IntegrationPage.test.tsx
+++ b/src/pages/integration/IntegrationPage.test.tsx
@@ -4,6 +4,8 @@ import * as React from "react";
 
 import { Tab, Tabs } from "react-toolbox";
 
+import Source from "../../models/source";
+import { dummySources } from "../../utils/test";
 import IntegrationExpressJS from "./IntegrationExpressJS";
 import IntegrationJava from "./IntegrationJava";
 import IntegrationNodeJS from "./IntegrationNodeJSLambda";
@@ -12,13 +14,15 @@ import IntegrationSpokes from "./IntegrationSpokes";
 
 const expect = chai.expect;
 
+const source: Source = dummySources(1)[0];
+
 describe("IntegrationPage", function () {
 
     describe("Rendering with key.", function () {
         let wrapper: ShallowWrapper<any, any>;
 
         before(function () {
-            wrapper = shallow(<IntegrationPage secretKey={"ABCD123"} />);
+            wrapper = shallow(<IntegrationPage source={source} />);
         });
 
         it ("Tests there are the appropriate number of tabs.", function() {
@@ -35,21 +39,21 @@ describe("IntegrationPage", function () {
             const tabPage = tab.find(IntegrationNodeJS); // TODO: I'm not sure why this doesn't work.
             // const tabPage = tab.childAt(0);
             expect(tabPage).to.have.length(1);
-            expect(tabPage.prop("secretKey")).to.equal("ABCD123");
+            expect(tabPage.prop("secretKey")).to.equal(source.secretKey);
         });
 
         it ("Tests the second tab is IntegrationExpressJS and gets the secret key.", function() {
             const tab = wrapper.find(Tab).at(1);
             const tabPage = tab.find(IntegrationExpressJS);
             expect(tabPage).to.have.length(1);
-            expect(tabPage.prop("secretKey")).to.equal("ABCD123");
+            expect(tabPage.prop("secretKey")).to.equal(source.secretKey);
         });
 
         it ("Tests the third tab is IntegrationJava and gets the secret key.", function() {
             const tab = wrapper.find(Tab).at(2);
             const tabPage = tab.find(IntegrationJava);
             expect(tabPage).to.have.length(1);
-            expect(tabPage.prop("secretKey")).to.equal("ABCD123");
+            expect(tabPage.prop("secretKey")).to.equal(source.secretKey);
         });
 
         it("Tests the Spoke Page exists", function() {
@@ -63,7 +67,7 @@ describe("IntegrationPage", function () {
         let wrapper: ShallowWrapper<any, any>;
 
         beforeEach(function () {
-            wrapper = shallow(<IntegrationPage secretKey={"ABCD123"} />);
+            wrapper = shallow(<IntegrationPage source={source} />);
         });
 
         it ("Tests the tab gets the appropriate state after change.", function() {

--- a/src/pages/integration/IntegrationPage.test.tsx
+++ b/src/pages/integration/IntegrationPage.test.tsx
@@ -25,16 +25,16 @@ describe("IntegrationPage", function () {
             wrapper = shallow(<IntegrationPage source={source} />);
         });
 
-        it ("Tests there are the appropriate number of tabs.", function() {
+        it("Tests there are the appropriate number of tabs.", function () {
             expect(wrapper.find(Tabs)).to.have.length(1);
             expect(wrapper.find(Tab)).to.have.length(4);
         });
 
-        it ("Tests the Tabs property has the default index.", function() {
+        it("Tests the Tabs property has the default index.", function () {
             expect(wrapper.find(Tabs).at(0).prop("index")).to.equal(0);
         });
 
-        it ("Tests the first tab is IntegrationNodeJS and gets the secret key.", function() {
+        it("Tests the first tab is IntegrationNodeJS and gets the secret key.", function () {
             const tab = wrapper.find(Tab).at(0);
             const tabPage = tab.find(IntegrationNodeJS); // TODO: I'm not sure why this doesn't work.
             // const tabPage = tab.childAt(0);
@@ -42,24 +42,61 @@ describe("IntegrationPage", function () {
             expect(tabPage.prop("secretKey")).to.equal(source.secretKey);
         });
 
-        it ("Tests the second tab is IntegrationExpressJS and gets the secret key.", function() {
+        it("Tests the second tab is IntegrationExpressJS and gets the secret key.", function () {
             const tab = wrapper.find(Tab).at(1);
             const tabPage = tab.find(IntegrationExpressJS);
             expect(tabPage).to.have.length(1);
             expect(tabPage.prop("secretKey")).to.equal(source.secretKey);
         });
 
-        it ("Tests the third tab is IntegrationJava and gets the secret key.", function() {
+        it("Tests the third tab is IntegrationJava and gets the secret key.", function () {
             const tab = wrapper.find(Tab).at(2);
             const tabPage = tab.find(IntegrationJava);
             expect(tabPage).to.have.length(1);
             expect(tabPage.prop("secretKey")).to.equal(source.secretKey);
         });
 
-        it("Tests the Spoke Page exists", function() {
+        it("Tests the Spoke Page exists", function () {
             const tab = wrapper.find(Tab).at(3);
             const tabPage = tab.find(IntegrationSpokes);
             expect(tabPage).to.have.length(1);
+        });
+    });
+
+    describe("Render without key", function () {
+        let wrapper: ShallowWrapper<any, any>;
+
+        before(function () {
+            wrapper = shallow(<IntegrationPage source={undefined} />);
+        });
+
+        it("Tests the first tab is IntegrationNodeJS and gets the secret key.", function () {
+            const tab = wrapper.find(Tab).at(0);
+            const tabPage = tab.find(IntegrationNodeJS); // TODO: I'm not sure why this doesn't work.
+            // const tabPage = tab.childAt(0);
+            expect(tabPage).to.have.length(1);
+            expect(tabPage.prop("secretKey")).to.be.undefined;
+        });
+
+        it("Tests the second tab is IntegrationExpressJS and gets the secret key.", function () {
+            const tab = wrapper.find(Tab).at(1);
+            const tabPage = tab.find(IntegrationExpressJS);
+            expect(tabPage).to.have.length(1);
+            expect(tabPage.prop("secretKey")).to.be.undefined;
+        });
+
+        it("Tests the third tab is IntegrationJava and gets the secret key.", function () {
+            const tab = wrapper.find(Tab).at(2);
+            const tabPage = tab.find(IntegrationJava);
+            expect(tabPage).to.have.length(1);
+            expect(tabPage.prop("secretKey")).to.be.undefined;
+        });
+
+        it("Tests the Spoke Page exists", function () {
+            const tab = wrapper.find(Tab).at(3);
+            const tabPage = tab.find(IntegrationSpokes);
+            expect(tabPage).to.have.length(1);
+            expect(tabPage.prop("source")).to.be.undefined;
         });
     });
 
@@ -70,7 +107,7 @@ describe("IntegrationPage", function () {
             wrapper = shallow(<IntegrationPage source={source} />);
         });
 
-        it ("Tests the tab gets the appropriate state after change.", function() {
+        it("Tests the tab gets the appropriate state after change.", function () {
             let tabs = wrapper.find(Tabs).at(0);
             tabs.simulate("change", 1);
 

--- a/src/pages/integration/IntegrationPage.tsx
+++ b/src/pages/integration/IntegrationPage.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { Tab, Tabs } from "react-toolbox";
 
 import ResizingComponent from "../../components/ResizingComponent";
-import Source from "../../models/Source";
+import Source from "../../models/source";
 import ExpressJS from "./IntegrationExpressJS";
 import Java from "./IntegrationJava";
 import NodeJS from "./IntegrationNodeJSLambda";

--- a/src/pages/integration/IntegrationPage.tsx
+++ b/src/pages/integration/IntegrationPage.tsx
@@ -6,6 +6,7 @@ import ResizingComponent from "../../components/ResizingComponent";
 import ExpressJS from "./IntegrationExpressJS";
 import Java from "./IntegrationJava";
 import NodeJS from "./IntegrationNodeJSLambda";
+import Spokes from "./IntegrationSpokes";
 
 let TabsTheme = require("./themes/tabs.scss");
 
@@ -52,6 +53,11 @@ export class IntegrationPage extends React.Component<IntegrationPageProps, Integ
                         <Tab label="Java">
                             <ResizingComponent>
                                 <Java secretKey={this.props.secretKey} showSecret={this.props.showSecret} />
+                            </ResizingComponent>
+                        </Tab>
+                        <Tab label="Spokes">
+                            <ResizingComponent>
+                                <Spokes />
                             </ResizingComponent>
                         </Tab>
                     </Tabs>

--- a/src/pages/integration/IntegrationPage.tsx
+++ b/src/pages/integration/IntegrationPage.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { Tab, Tabs } from "react-toolbox";
 
 import ResizingComponent from "../../components/ResizingComponent";
+import Source from "../../models/Source";
 import ExpressJS from "./IntegrationExpressJS";
 import Java from "./IntegrationJava";
 import NodeJS from "./IntegrationNodeJSLambda";
@@ -11,7 +12,7 @@ import Spokes from "./IntegrationSpokes";
 let TabsTheme = require("./themes/tabs.scss");
 
 interface IntegrationPageProps {
-    secretKey?: string;
+    source: Source;
     showSecret?: boolean;
 }
 
@@ -36,28 +37,32 @@ export class IntegrationPage extends React.Component<IntegrationPageProps, Integ
     }
 
     render() {
+        const { tabIndex } = this.state;
+        const { showSecret, source } = this.props;
+        const { secretKey } = source;
         return (
             <ResizingComponent overflowY="hidden" >
                 <section>
-                    <Tabs theme={TabsTheme} fixed inverse index={this.state.tabIndex} onChange={this.handleTabChange} >
+                    <Tabs theme={TabsTheme} fixed inverse index={tabIndex} onChange={this.handleTabChange} >
                         <Tab label="Node.JS Lambda">
                             <ResizingComponent>
-                                <NodeJS secretKey={this.props.secretKey} showSecret={this.props.showSecret} />
+                                <NodeJS secretKey={secretKey} showSecret={showSecret} />
                             </ResizingComponent>
                         </Tab>
                         <Tab label="Express.JS">
                             <ResizingComponent>
-                                <ExpressJS secretKey={this.props.secretKey} showSecret={this.props.showSecret} />
+                                <ExpressJS secretKey={secretKey} showSecret={showSecret} />
                             </ResizingComponent>
                         </Tab>
                         <Tab label="Java">
                             <ResizingComponent>
-                                <Java secretKey={this.props.secretKey} showSecret={this.props.showSecret} />
+                                <Java secretKey={secretKey} showSecret={showSecret} />
                             </ResizingComponent>
                         </Tab>
                         <Tab label="Spokes">
                             <ResizingComponent>
-                                <Spokes />
+                                <Spokes
+                                source={source} />
                             </ResizingComponent>
                         </Tab>
                     </Tabs>

--- a/src/pages/integration/IntegrationPage.tsx
+++ b/src/pages/integration/IntegrationPage.tsx
@@ -39,7 +39,7 @@ export class IntegrationPage extends React.Component<IntegrationPageProps, Integ
     render() {
         const { tabIndex } = this.state;
         const { showSecret, source } = this.props;
-        const { secretKey } = source;
+        const secretKey = (source) ? source.secretKey : undefined;
         return (
             <ResizingComponent overflowY="hidden" >
                 <section>

--- a/src/pages/integration/IntegrationPage.tsx
+++ b/src/pages/integration/IntegrationPage.tsx
@@ -44,6 +44,11 @@ export class IntegrationPage extends React.Component<IntegrationPageProps, Integ
             <ResizingComponent overflowY="hidden" >
                 <section>
                     <Tabs theme={TabsTheme} fixed inverse index={tabIndex} onChange={this.handleTabChange} >
+                        <Tab label="Spokes">
+                            <ResizingComponent>
+                                <Spokes source={source} />
+                            </ResizingComponent>
+                        </Tab>
                         <Tab label="Node.JS Lambda">
                             <ResizingComponent>
                                 <NodeJS secretKey={secretKey} showSecret={showSecret} />
@@ -57,12 +62,6 @@ export class IntegrationPage extends React.Component<IntegrationPageProps, Integ
                         <Tab label="Java">
                             <ResizingComponent>
                                 <Java secretKey={secretKey} showSecret={showSecret} />
-                            </ResizingComponent>
-                        </Tab>
-                        <Tab label="Spokes">
-                            <ResizingComponent>
-                                <Spokes
-                                source={source} />
                             </ResizingComponent>
                         </Tab>
                     </Tabs>

--- a/src/pages/integration/IntegrationSpokes.test.tsx
+++ b/src/pages/integration/IntegrationSpokes.test.tsx
@@ -1,0 +1,31 @@
+import * as chai from "chai";
+import { shallow, ShallowWrapper } from "enzyme";
+import * as React from "react";
+import * as sinon from "sinon";
+import * as sinonChai from "sinon-chai";
+
+import IntegrationSpokes from "./IntegrationSpokes";
+import IntegrationSpokesSwapper from "./IntegrationSpokesSwapper";
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe("IntegrationSpokes", function() {
+    describe("Renders", function() {
+        let wrapper: ShallowWrapper<any, any>;
+        let onChange: Sinon.SinonStub;
+
+        before(function() {
+            onChange = sinon.stub();
+            wrapper = shallow(<IntegrationSpokes />);
+        });
+
+        afterEach(function() {
+            onChange.reset();
+        });
+
+        it("Tests the swapper is there.", function() {
+            expect(wrapper.find(IntegrationSpokesSwapper)).to.have.length(1);
+        });
+    });
+});

--- a/src/pages/integration/IntegrationSpokes.test.tsx
+++ b/src/pages/integration/IntegrationSpokes.test.tsx
@@ -57,6 +57,10 @@ describe("IntegrationSpokes", function () {
             expect(wrapper.find(Button).at(0)).to.have.prop("label", "Save");
         });
 
+        it("Tests the error message exists.", function () {
+            expect(wrapper.find("span")).to.have.length(1);
+        });
+
         it("Tests the dropdown for page selector exists.", function () {
             expect(wrapper.find(Dropdown)).to.have.length(1);
         });
@@ -124,7 +128,7 @@ describe("IntegrationSpokes", function () {
                     expect(button).to.have.prop("disabled", false);
                 });
 
-                it("Tests that the save button is disabled when url is not actually a url.", function() {
+                it("Tests that the save button is disabled when url is not actually a url.", function () {
                     wrapper.setState({ url: "Hahaha You think this is real?" });
                     const button = wrapper.find(Button).at(0);
                     expect(button).to.have.prop("disabled", true);
@@ -214,6 +218,10 @@ describe("IntegrationSpokes", function () {
                 saveSpoke = sinon.stub(SpokesService, "savePipe").returns(Promise.resolve());
             });
 
+            after(function () {
+                saveSpoke.restore();
+            });
+
             it("Tests the appropriate parameters are passed in on HTTP.", function () {
                 wrapper.setState({ showPage: "http", enableLiveDebugging: true, url: "http://test.url.fake/", arn: "fakeARN", iamAccessKey: "ABC123", iamSecretKey: "123ABC" });
 
@@ -253,6 +261,40 @@ describe("IntegrationSpokes", function () {
                     .then(function () {
                         expect(onSaved).to.be.calledOnce;
                     });
+            });
+
+            it("Tests that the success message is displayed", function () {
+                const button = wrapper.find(Button).at(0);
+                button.simulate("click");
+
+                const promise = (wrapper.instance() as IntegrationSpokes).cancelables[0] as any;
+                return promise.then(function () {
+                    const message = wrapper.find("span").at(0);
+                    expect(message.text()).to.exist;
+                    expect(message).to.have.style("color", "#000000"); // it's black.
+                });
+            });
+        });
+
+        describe("Unsuccessful saves", function () {
+            before(function () {
+                saveSpoke = sinon.stub(SpokesService, "savePipe").returns(Promise.reject(new Error("Error per requirements of the test.")));
+            });
+
+            after(function () {
+                saveSpoke.restore();
+            });
+
+            it("Tests that the error message was displayed on error.", function () {
+                const button = wrapper.find(Button).at(0);
+                button.simulate("click");
+
+                const promise = (wrapper.instance() as IntegrationSpokes).cancelables[0] as any;
+                return promise.then(function () {
+                    const message = wrapper.find("span").at(0);
+                    expect(message.text()).to.exist;
+                    expect(message).to.have.style("color", "#FF0000"); // it's red.
+                });
             });
         });
     });

--- a/src/pages/integration/IntegrationSpokes.test.tsx
+++ b/src/pages/integration/IntegrationSpokes.test.tsx
@@ -58,7 +58,7 @@ describe("IntegrationSpokes", function () {
         });
 
         it("Tests the error message exists.", function () {
-            expect(wrapper.find("span")).to.have.length(1);
+            expect(wrapper.find("p")).to.have.length(1);
         });
 
         it("Tests the dropdown for page selector exists.", function () {
@@ -269,7 +269,7 @@ describe("IntegrationSpokes", function () {
 
                 const promise = (wrapper.instance() as IntegrationSpokes).cancelables[0] as any;
                 return promise.then(function () {
-                    const message = wrapper.find("span").at(0);
+                    const message = wrapper.find("p").at(0);
                     expect(message.text()).to.exist;
                     expect(message).to.have.style("color", "#000000"); // it's black.
                 });
@@ -291,7 +291,7 @@ describe("IntegrationSpokes", function () {
 
                 const promise = (wrapper.instance() as IntegrationSpokes).cancelables[0] as any;
                 return promise.then(function () {
-                    const message = wrapper.find("span").at(0);
+                    const message = wrapper.find("p").at(0);
                     expect(message.text()).to.exist;
                     expect(message).to.have.style("color", "#FF0000"); // it's red.
                 });

--- a/src/pages/integration/IntegrationSpokes.test.tsx
+++ b/src/pages/integration/IntegrationSpokes.test.tsx
@@ -58,7 +58,8 @@ describe("IntegrationSpokes", function () {
         });
 
         it("Tests the error message exists.", function () {
-            expect(wrapper.find("p")).to.have.length(1);
+            expect(wrapper.find("p")).to.have.length(3); // There's two banner messages as well.
+            expect(wrapper.find("p").at(2)).to.have.style("visibility", "hidden");
         });
 
         it("Tests the dropdown for page selector exists.", function () {
@@ -269,7 +270,7 @@ describe("IntegrationSpokes", function () {
 
                 const promise = (wrapper.instance() as IntegrationSpokes).cancelables[0] as any;
                 return promise.then(function () {
-                    const message = wrapper.find("p").at(0);
+                    const message = wrapper.find("p").at(2);
                     expect(message.text()).to.exist;
                     expect(message).to.have.style("color", "#000000"); // it's black.
                 });
@@ -291,7 +292,7 @@ describe("IntegrationSpokes", function () {
 
                 const promise = (wrapper.instance() as IntegrationSpokes).cancelables[0] as any;
                 return promise.then(function () {
-                    const message = wrapper.find("p").at(0);
+                    const message = wrapper.find("p").at(2);
                     expect(message.text()).to.exist;
                     expect(message).to.have.style("color", "#FF0000"); // it's red.
                 });

--- a/src/pages/integration/IntegrationSpokes.test.tsx
+++ b/src/pages/integration/IntegrationSpokes.test.tsx
@@ -8,86 +8,164 @@ import { Button } from "react-toolbox/lib/button";
 import Checkbox from "react-toolbox/lib/checkbox";
 import Dropdown from "react-toolbox/lib/dropdown";
 
-import IntegrationSpokes from "./IntegrationSpokes";
+import Source from "../../models/source";
+import User from "../../models/user";
+import SpokesService from "../../services/spokes";
+import { dummySources } from "../../utils/test";
+import { IntegrationSpokes } from "./IntegrationSpokes";
 import IntegrationSpokesSwapper from "./IntegrationSpokesSwapper";
 
 chai.use(sinonChai);
 const expect = chai.expect;
 
-describe("IntegrationSpokes", function() {
-    describe("Renders", function() {
+const source: Source = dummySources(1)[0];
+const user = new User({ email: "test@testMctest.com" });
+
+describe("IntegrationSpokes", function () {
+    describe("Renders", function () {
         let wrapper: ShallowWrapper<any, any>;
-        let onChange: Sinon.SinonStub;
+        // let onChange: Sinon.SinonStub;
+        let onSaved: Sinon.SinonStub;
 
-        before(function() {
-            onChange = sinon.stub();
-            wrapper = shallow(<IntegrationSpokes />);
+        before(function () {
+            onSaved = sinon.stub();
+            wrapper = shallow(<IntegrationSpokes user={user} source={source} onSpokesSaved={onSaved} />);
         });
 
-        afterEach(function() {
-            onChange.reset();
+        afterEach(function () {
+            onSaved.reset();
         });
 
-        it("Tests the swapper is there.", function() {
+        it("Tests the swapper is there.", function () {
             expect(wrapper.find(IntegrationSpokesSwapper)).to.have.length(1);
         });
 
-        it("Tests the enable live debugging checkbox exists.", function() {
+        it("Tests the enable live debugging checkbox exists.", function () {
             expect(wrapper.find(Checkbox)).to.have.length(1);
             expect(wrapper.find(Checkbox).at(0)).to.have.prop("label", "Enable Live Debugging");
             expect(wrapper.find(Checkbox).at(0)).to.have.prop("checked", false);
         });
 
-        it("Tests the save button exists.", function() {
+        it("Tests the save button exists.", function () {
             expect(wrapper.find(Button)).to.have.length(1);
             expect(wrapper.find(Button).at(0)).to.have.prop("label", "Save");
         });
 
-        it("Tests the dropdown for page selector exists.", function() {
+        it("Tests the dropdown for page selector exists.", function () {
             expect(wrapper.find(Dropdown)).to.have.length(1);
         });
 
-        it("Tests the default page", function() {
+        it("Tests the default page", function () {
             expect(wrapper.find(Dropdown).at(0)).to.have.prop("value", "http");
             expect(wrapper.find(IntegrationSpokesSwapper).at(0)).to.have.prop("showPage", "http");
         });
 
-        it("Tests the enable live debugging checkbox works.", function() {
+        it("Tests the enable live debugging checkbox works.", function () {
             let checkbox = wrapper.find(Checkbox).at(0);
             checkbox.simulate("change", true);
 
             expect(wrapper.find(Checkbox).at(0)).to.have.prop("checked", true);
         });
 
-        describe("IntegrationSpokesSwapper State", function() {
+        describe("IntegrationSpokesSwapper State", function () {
             let swapper: ShallowWrapper<any, any>;
 
-            beforeEach(function() {
+            beforeEach(function () {
                 swapper = wrapper.find(IntegrationSpokesSwapper).at(0);
             });
 
-            it("Tests the http change will give the value to swapper.", function() {
+            it("Tests the http change will give the value to swapper.", function () {
                 swapper.simulate("change", "url", "New URL");
 
                 expect(wrapper.find(IntegrationSpokesSwapper).at(0)).to.have.prop("url", "New URL");
             });
 
-            it("Tests the ARN change will give the value to swapper.", function() {
+            it("Tests the ARN change will give the value to swapper.", function () {
                 swapper.simulate("change", "arn", "New ARN");
 
                 expect(wrapper.find(IntegrationSpokesSwapper).at(0)).to.have.prop("arn", "New ARN");
             });
 
-            it("Tests the IAM Access key change will give the value to swapper.", function() {
+            it("Tests the IAM Access key change will give the value to swapper.", function () {
                 swapper.simulate("change", "iamAccessKey", "New Access Key");
 
                 expect(wrapper.find(IntegrationSpokesSwapper).at(0)).to.have.prop("iamAccessKey", "New Access Key");
             });
 
-            it("Tests the IAM Secret key change will give the value to swapper.", function() {
+            it("Tests the IAM Secret key change will give the value to swapper.", function () {
                 swapper.simulate("change", "iamSecretKey", "New Secret Key");
 
                 expect(wrapper.find(IntegrationSpokesSwapper).at(0)).to.have.prop("iamSecretKey", "New Secret Key");
+            });
+        });
+    });
+
+    describe("Saving Spokes", function () {
+        let wrapper: ShallowWrapper<any, any>;
+        let onSaved: Sinon.SinonStub;
+        let saveSpoke: Sinon.SinonStub;
+
+        before(function () {
+            onSaved = sinon.stub();
+        });
+
+        beforeEach(function () {
+            wrapper = shallow(<IntegrationSpokes user={user} source={source} onSpokesSaved={onSaved} />);
+        });
+
+        afterEach(function () {
+            onSaved.reset();
+            saveSpoke.reset();
+        });
+
+        after(function () {
+            saveSpoke.restore();
+        });
+
+        describe("Successful saves", function () {
+            before(function () {
+                saveSpoke = sinon.stub(SpokesService, "savePipe").returns(Promise.resolve());
+            });
+
+            it("Tests the appropriate parameters are passed in on HTTP.", function () {
+                wrapper.setState({ showPage: "http", enableLiveDebugging: true, url: "http://test.url.fake/", arn: "fakeARN", iamAccessKey: "ABC123", iamSecretKey: "123ABC" });
+
+                const button = wrapper.find(Button).at(0);
+                button.simulate("click");
+
+                expect(saveSpoke).to.be.calledOnce;
+                const args = saveSpoke.args[0];
+                expect(args[0]).to.deep.equal(user);
+                expect(args[1]).to.deep.equal(source);
+                expect(args[2]).to.deep.equal({ url: "http://test.url.fake/" });
+                expect(args[3]).to.deep.equal(true);
+            });
+
+            it("Tests the appropriate parameters are passed in on lambda.", function () {
+                wrapper.setState({ showPage: "lambda", enableLiveDebugging: true, url: "http://test.url.fake/", arn: "fakeARN", iamAccessKey: "ABC123", iamSecretKey: "123ABC" });
+
+                const button = wrapper.find(Button).at(0);
+                button.simulate("click");
+
+                expect(saveSpoke).to.be.calledOnce;
+                const args = saveSpoke.args[0];
+                expect(args[0]).to.deep.equal(user);
+                expect(args[1]).to.deep.equal(source);
+                expect(args[2]).to.deep.equal({ awsAccessKey: "ABC123", awsSecretKey: "123ABC", lambdaARN: "fakeARN" });
+                expect(args[3]).to.deep.equal(true);
+            });
+
+            it("Tests that the callback is called.", function () {
+                wrapper.setState({ showPage: "http", enableLiveDebugging: true, url: "http://test.url.fake/", arn: "fakeARN", iamAccessKey: "ABC123", iamSecretKey: "123ABC" });
+
+                const button = wrapper.find(Button).at(0);
+                button.simulate("click");
+
+                return (wrapper.instance() as IntegrationSpokes)
+                    .savingPromise
+                    .then(function () {
+                        expect(onSaved).to.be.calledOnce;
+                    });
             });
         });
     });

--- a/src/pages/integration/IntegrationSpokes.test.tsx
+++ b/src/pages/integration/IntegrationSpokes.test.tsx
@@ -4,6 +4,10 @@ import * as React from "react";
 import * as sinon from "sinon";
 import * as sinonChai from "sinon-chai";
 
+import { Button } from "react-toolbox/lib/button";
+import Checkbox from "react-toolbox/lib/checkbox";
+import Dropdown from "react-toolbox/lib/dropdown";
+
 import IntegrationSpokes from "./IntegrationSpokes";
 import IntegrationSpokesSwapper from "./IntegrationSpokesSwapper";
 
@@ -26,6 +30,65 @@ describe("IntegrationSpokes", function() {
 
         it("Tests the swapper is there.", function() {
             expect(wrapper.find(IntegrationSpokesSwapper)).to.have.length(1);
+        });
+
+        it("Tests the enable live debugging checkbox exists.", function() {
+            expect(wrapper.find(Checkbox)).to.have.length(1);
+            expect(wrapper.find(Checkbox).at(0)).to.have.prop("label", "Enable Live Debugging");
+            expect(wrapper.find(Checkbox).at(0)).to.have.prop("checked", false);
+        });
+
+        it("Tests the save button exists.", function() {
+            expect(wrapper.find(Button)).to.have.length(1);
+            expect(wrapper.find(Button).at(0)).to.have.prop("label", "Save");
+        });
+
+        it("Tests the dropdown for page selector exists.", function() {
+            expect(wrapper.find(Dropdown)).to.have.length(1);
+        });
+
+        it("Tests the default page", function() {
+            expect(wrapper.find(Dropdown).at(0)).to.have.prop("value", "http");
+            expect(wrapper.find(IntegrationSpokesSwapper).at(0)).to.have.prop("showPage", "http");
+        });
+
+        it("Tests the enable live debugging checkbox works.", function() {
+            let checkbox = wrapper.find(Checkbox).at(0);
+            checkbox.simulate("change", true);
+
+            expect(wrapper.find(Checkbox).at(0)).to.have.prop("checked", true);
+        });
+
+        describe("IntegrationSpokesSwapper State", function() {
+            let swapper: ShallowWrapper<any, any>;
+
+            beforeEach(function() {
+                swapper = wrapper.find(IntegrationSpokesSwapper).at(0);
+            });
+
+            it("Tests the http change will give the value to swapper.", function() {
+                swapper.simulate("change", "url", "New URL");
+
+                expect(wrapper.find(IntegrationSpokesSwapper).at(0)).to.have.prop("url", "New URL");
+            });
+
+            it("Tests the ARN change will give the value to swapper.", function() {
+                swapper.simulate("change", "arn", "New ARN");
+
+                expect(wrapper.find(IntegrationSpokesSwapper).at(0)).to.have.prop("arn", "New ARN");
+            });
+
+            it("Tests the IAM Access key change will give the value to swapper.", function() {
+                swapper.simulate("change", "iamAccessKey", "New Access Key");
+
+                expect(wrapper.find(IntegrationSpokesSwapper).at(0)).to.have.prop("iamAccessKey", "New Access Key");
+            });
+
+            it("Tests the IAM Secret key change will give the value to swapper.", function() {
+                swapper.simulate("change", "iamSecretKey", "New Secret Key");
+
+                expect(wrapper.find(IntegrationSpokesSwapper).at(0)).to.have.prop("iamSecretKey", "New Secret Key");
+            });
         });
     });
 });

--- a/src/pages/integration/IntegrationSpokes.test.tsx
+++ b/src/pages/integration/IntegrationSpokes.test.tsx
@@ -26,13 +26,19 @@ describe("IntegrationSpokes", function () {
         let wrapper: ShallowWrapper<any, any>;
         // let onChange: Sinon.SinonStub;
         let onSaved: Sinon.SinonStub;
+        let savedState: any;
 
         before(function () {
             onSaved = sinon.stub();
             wrapper = shallow(<IntegrationSpokes user={user} source={source} onSpokesSaved={onSaved} />);
         });
 
+        beforeEach(function () {
+            savedState = wrapper.state();
+        });
+
         afterEach(function () {
+            wrapper.setState(wrapper);
             onSaved.reset();
         });
 
@@ -96,6 +102,81 @@ describe("IntegrationSpokes", function () {
                 swapper.simulate("change", "iamSecretKey", "New Secret Key");
 
                 expect(wrapper.find(IntegrationSpokesSwapper).at(0)).to.have.prop("iamSecretKey", "New Secret Key");
+            });
+        });
+
+        describe("Disabling and enabling save button", function () {
+            describe("In http page", function () {
+
+                beforeEach(function () {
+                    wrapper.setState({ showPage: "http" });
+                });
+
+                it("Tests that the save button is disabled when url is undefined.", function () {
+                    wrapper.setState({ url: undefined });
+                    const button = wrapper.find(Button).at(0);
+                    expect(button).to.have.prop("disabled", true);
+                });
+
+                it("Tests that the save button is enabled when url is defined.", function () {
+                    wrapper.setState({ url: "https://www.test.url/" });
+                    const button = wrapper.find(Button).at(0);
+                    expect(button).to.have.prop("disabled", false);
+                });
+            });
+
+            describe("In lambda page", function () {
+                beforeEach(function () {
+                    wrapper.setState({ showPage: "lambda" });
+                });
+
+                it("Tests that the save button is disabled when arn, iamAccessKey, and iamSecretKey are undefined.", function () {
+                    wrapper.setState({ arn: undefined, iamAccessKey: undefined, iamSecretKey: undefined });
+                    const button = wrapper.find(Button).at(0);
+                    expect(button).to.have.prop("disabled", true);
+                });
+
+                it("Tests that the save button is enabled when arn, iamAccessKey, and iamSecretKey are defined.", function () {
+                    wrapper.setState({ arn: "123ABC", iamAccessKey: "ABC123", iamSecretKey: "AABBCC112233" });
+                    const button = wrapper.find(Button).at(0);
+                    expect(button).to.have.prop("disabled", false);
+                });
+
+                it("Tests that the save button is disabled only when arn is undefined.", function () {
+                    wrapper.setState({ iamAccessKey: "ABC123", iamSecretKey: "AABBCC112233" });
+                    const button = wrapper.find(Button).at(0);
+                    expect(button).to.have.prop("disabled", false);
+                });
+
+                it("Tests that the save button is disabled only when iamAccessKey is undefined.", function () {
+                    wrapper.setState({ arn: "123ABC", iamSecretKey: "AABBCC112233" });
+                    const button = wrapper.find(Button).at(0);
+                    expect(button).to.have.prop("disabled", false);
+                });
+
+                it("Tests that the save button is disabled only when iamSecretKey is undefined.", function () {
+                    wrapper.setState({ arn: "123ABC", iamAccessKey: "ABC123" });
+                    const button = wrapper.find(Button).at(0);
+                    expect(button).to.have.prop("disabled", false);
+                });
+            });
+
+            describe("Some random page", function () {
+                let savedState: any;
+                before(function () {
+                    savedState = wrapper.state();
+                    wrapper.setState({ showPage: "Page That does not exist." });
+                });
+
+                after(function () {
+                    wrapper.setState(savedState);
+                });
+
+                it("Tests that the save button is disabled when the page is unknown to the component.", function () {
+                    wrapper.setState({ arn: "123ABC", iamAccessKey: "ABC123", iamSecretKey: "AABBCC112233" });
+                    const button = wrapper.find(Button).at(0);
+                    expect(button).to.have.prop("disabled", true);
+                });
             });
         });
     });

--- a/src/pages/integration/IntegrationSpokes.test.tsx
+++ b/src/pages/integration/IntegrationSpokes.test.tsx
@@ -27,10 +27,17 @@ describe("IntegrationSpokes", function () {
         // let onChange: Sinon.SinonStub;
         let onSaved: Sinon.SinonStub;
         let savedState: any;
+        let prefetch: Sinon.SinonStub;
 
         before(function () {
             onSaved = sinon.stub();
+            // All of these tests were written *before* the prefetch was added so we're going to skip it and assume the spokes are fresh.
+            prefetch = sinon.stub(SpokesService, "fetchPipe").returns(Promise.reject(new Error("Error per requirements of the test.")));
+
             wrapper = shallow(<IntegrationSpokes user={user} source={source} onSpokesSaved={onSaved} />);
+
+            const prefetchPromise = (wrapper.instance() as IntegrationSpokes).cancelables[0] as any;
+            return prefetchPromise.catch(function() { /* don't care */}); // Lets this run through without worry.
         });
 
         beforeEach(function () {
@@ -40,6 +47,10 @@ describe("IntegrationSpokes", function () {
         afterEach(function () {
             wrapper.setState(wrapper);
             onSaved.reset();
+        });
+
+        after(function() {
+            prefetch.restore();
         });
 
         it("Tests the swapper is there.", function () {
@@ -92,21 +103,21 @@ describe("IntegrationSpokes", function () {
             });
 
             it("Tests the ARN change will give the value to swapper.", function () {
-                swapper.simulate("change", "arn", "New ARN");
+                swapper.simulate("change", "lambdaARN", "New ARN");
 
-                expect(wrapper.find(IntegrationSpokesSwapper).at(0)).to.have.prop("arn", "New ARN");
+                expect(wrapper.find(IntegrationSpokesSwapper).at(0)).to.have.prop("lambdaARN", "New ARN");
             });
 
             it("Tests the IAM Access key change will give the value to swapper.", function () {
-                swapper.simulate("change", "iamAccessKey", "New Access Key");
+                swapper.simulate("change", "awsAccessKey", "New Access Key");
 
-                expect(wrapper.find(IntegrationSpokesSwapper).at(0)).to.have.prop("iamAccessKey", "New Access Key");
+                expect(wrapper.find(IntegrationSpokesSwapper).at(0)).to.have.prop("awsAccessKey", "New Access Key");
             });
 
             it("Tests the IAM Secret key change will give the value to swapper.", function () {
-                swapper.simulate("change", "iamSecretKey", "New Secret Key");
+                swapper.simulate("change", "awsSecretKey", "New Secret Key");
 
-                expect(wrapper.find(IntegrationSpokesSwapper).at(0)).to.have.prop("iamSecretKey", "New Secret Key");
+                expect(wrapper.find(IntegrationSpokesSwapper).at(0)).to.have.prop("awsSecretKey", "New Secret Key");
             });
         });
 
@@ -141,32 +152,32 @@ describe("IntegrationSpokes", function () {
                     wrapper.setState({ showPage: "lambda" });
                 });
 
-                it("Tests that the save button is disabled when arn, iamAccessKey, and iamSecretKey are undefined.", function () {
-                    wrapper.setState({ arn: undefined, iamAccessKey: undefined, iamSecretKey: undefined });
+                it("Tests that the save button is disabled when lambdaARN, awsAccessKey, and awsSecretKey are undefined.", function () {
+                    wrapper.setState({ lambdaARN: undefined, awsAccessKey: undefined, awsSecretKey: undefined });
                     const button = wrapper.find(Button).at(0);
                     expect(button).to.have.prop("disabled", true);
                 });
 
-                it("Tests that the save button is enabled when arn, iamAccessKey, and iamSecretKey are defined.", function () {
-                    wrapper.setState({ arn: "123ABC", iamAccessKey: "ABC123", iamSecretKey: "AABBCC112233" });
+                it("Tests that the save button is enabled when lambdaARN, awsAccessKey, and awsSecretKey are defined.", function () {
+                    wrapper.setState({ lambdaARN: "123ABC", awsAccessKey: "ABC123", awsSecretKey: "AABBCC112233" });
                     const button = wrapper.find(Button).at(0);
                     expect(button).to.have.prop("disabled", false);
                 });
 
-                it("Tests that the save button is disabled only when arn is undefined.", function () {
-                    wrapper.setState({ iamAccessKey: "ABC123", iamSecretKey: "AABBCC112233" });
+                it("Tests that the save button is disabled only when lambdaARN is undefined.", function () {
+                    wrapper.setState({ awsAccessKey: "ABC123", awsSecretKey: "AABBCC112233" });
                     const button = wrapper.find(Button).at(0);
                     expect(button).to.have.prop("disabled", false);
                 });
 
-                it("Tests that the save button is disabled only when iamAccessKey is undefined.", function () {
-                    wrapper.setState({ arn: "123ABC", iamSecretKey: "AABBCC112233" });
+                it("Tests that the save button is disabled only when awsAccessKey is undefined.", function () {
+                    wrapper.setState({ lambdaARN: "123ABC", awsSecretKey: "AABBCC112233" });
                     const button = wrapper.find(Button).at(0);
                     expect(button).to.have.prop("disabled", false);
                 });
 
-                it("Tests that the save button is disabled only when iamSecretKey is undefined.", function () {
-                    wrapper.setState({ arn: "123ABC", iamAccessKey: "ABC123" });
+                it("Tests that the save button is disabled only when awsSecretKey is undefined.", function () {
+                    wrapper.setState({ lambdaARN: "123ABC", awsAccessKey: "ABC123" });
                     const button = wrapper.find(Button).at(0);
                     expect(button).to.have.prop("disabled", false);
                 });
@@ -184,7 +195,7 @@ describe("IntegrationSpokes", function () {
                 });
 
                 it("Tests that the save button is disabled when the page is unknown to the component.", function () {
-                    wrapper.setState({ arn: "123ABC", iamAccessKey: "ABC123", iamSecretKey: "AABBCC112233" });
+                    wrapper.setState({ lambdaARN: "123ABC", awsAccessKey: "ABC123", awsSecretKey: "AABBCC112233" });
                     const button = wrapper.find(Button).at(0);
                     expect(button).to.have.prop("disabled", true);
                 });
@@ -195,14 +206,18 @@ describe("IntegrationSpokes", function () {
     describe("Saving Spokes", function () {
         let wrapper: ShallowWrapper<any, any>;
         let onSaved: Sinon.SinonStub;
+        let prefetch: Sinon.SinonStub;
         let saveSpoke: Sinon.SinonStub;
 
         before(function () {
             onSaved = sinon.stub();
+            prefetch = sinon.stub(SpokesService, "fetchPipe").returns(Promise.reject(new Error("Error per requirements of the test.")));
         });
 
         beforeEach(function () {
             wrapper = shallow(<IntegrationSpokes user={user} source={source} onSpokesSaved={onSaved} />);
+            const promise = (wrapper.instance() as IntegrationSpokes).cancelables[0] as any;
+            return promise.catch(function() { /* don't care */ });
         });
 
         afterEach(function () {
@@ -212,6 +227,7 @@ describe("IntegrationSpokes", function () {
 
         after(function () {
             saveSpoke.restore();
+            prefetch.restore();
         });
 
         describe("Successful saves", function () {
@@ -224,7 +240,7 @@ describe("IntegrationSpokes", function () {
             });
 
             it("Tests the appropriate parameters are passed in on HTTP.", function () {
-                wrapper.setState({ showPage: "http", enableLiveDebugging: true, url: "http://test.url.fake/", arn: "fakeARN", iamAccessKey: "ABC123", iamSecretKey: "123ABC" });
+                wrapper.setState({ showPage: "http", enableLiveDebugging: true, url: "http://test.url.fake/", lambdaARN: "fakeARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" });
 
                 const button = wrapper.find(Button).at(0);
                 button.simulate("click");
@@ -238,7 +254,7 @@ describe("IntegrationSpokes", function () {
             });
 
             it("Tests the appropriate parameters are passed in on lambda.", function () {
-                wrapper.setState({ showPage: "lambda", enableLiveDebugging: true, url: "http://test.url.fake/", arn: "fakeARN", iamAccessKey: "ABC123", iamSecretKey: "123ABC" });
+                wrapper.setState({ showPage: "lambda", enableLiveDebugging: true, url: "http://test.url.fake/", lambdaARN: "fakeARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" });
 
                 const button = wrapper.find(Button).at(0);
                 button.simulate("click");
@@ -252,7 +268,7 @@ describe("IntegrationSpokes", function () {
             });
 
             it("Tests that the callback is called.", function () {
-                wrapper.setState({ showPage: "http", enableLiveDebugging: true, url: "http://test.url.fake/", arn: "fakeARN", iamAccessKey: "ABC123", iamSecretKey: "123ABC" });
+                wrapper.setState({ showPage: "http", enableLiveDebugging: true, url: "http://test.url.fake/", lambdaARN: "fakeARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" });
 
                 const button = wrapper.find(Button).at(0);
                 button.simulate("click");

--- a/src/pages/integration/IntegrationSpokes.test.tsx
+++ b/src/pages/integration/IntegrationSpokes.test.tsx
@@ -161,8 +161,8 @@ describe("IntegrationSpokes", function () {
                 const button = wrapper.find(Button).at(0);
                 button.simulate("click");
 
-                return (wrapper.instance() as IntegrationSpokes)
-                    .savingPromise
+                const promise = (wrapper.instance() as IntegrationSpokes).cancelables[0] as any;
+                return promise
                     .then(function () {
                         expect(onSaved).to.be.calledOnce;
                     });

--- a/src/pages/integration/IntegrationSpokes.test.tsx
+++ b/src/pages/integration/IntegrationSpokes.test.tsx
@@ -240,7 +240,7 @@ describe("IntegrationSpokes", function () {
             });
 
             it("Tests the appropriate parameters are passed in on HTTP.", function () {
-                wrapper.setState({ showPage: "http", enableLiveDebugging: true, url: "http://test.url.fake/", lambdaARN: "fakeARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" });
+                wrapper.setState({ showPage: "http", proxy: true, url: "http://test.url.fake/", lambdaARN: "fakeARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" });
 
                 const button = wrapper.find(Button).at(0);
                 button.simulate("click");
@@ -254,7 +254,7 @@ describe("IntegrationSpokes", function () {
             });
 
             it("Tests the appropriate parameters are passed in on lambda.", function () {
-                wrapper.setState({ showPage: "lambda", enableLiveDebugging: true, url: "http://test.url.fake/", lambdaARN: "fakeARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" });
+                wrapper.setState({ showPage: "lambda", proxy: true, url: "http://test.url.fake/", lambdaARN: "fakeARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" });
 
                 const button = wrapper.find(Button).at(0);
                 button.simulate("click");
@@ -268,7 +268,7 @@ describe("IntegrationSpokes", function () {
             });
 
             it("Tests that the callback is called.", function () {
-                wrapper.setState({ showPage: "http", enableLiveDebugging: true, url: "http://test.url.fake/", lambdaARN: "fakeARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" });
+                wrapper.setState({ showPage: "http", proxy: true, url: "http://test.url.fake/", lambdaARN: "fakeARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" });
 
                 const button = wrapper.find(Button).at(0);
                 button.simulate("click");

--- a/src/pages/integration/IntegrationSpokes.test.tsx
+++ b/src/pages/integration/IntegrationSpokes.test.tsx
@@ -123,6 +123,12 @@ describe("IntegrationSpokes", function () {
                     const button = wrapper.find(Button).at(0);
                     expect(button).to.have.prop("disabled", false);
                 });
+
+                it("Tests that the save button is disabled when url is not actually a url.", function() {
+                    wrapper.setState({ url: "Hahaha You think this is real?" });
+                    const button = wrapper.find(Button).at(0);
+                    expect(button).to.have.prop("disabled", true);
+                });
             });
 
             describe("In lambda page", function () {

--- a/src/pages/integration/IntegrationSpokes.tsx
+++ b/src/pages/integration/IntegrationSpokes.tsx
@@ -28,9 +28,12 @@ interface IntegrationSpokesGlobalStateProps {
     user: User;
 }
 
-interface IntegrationSpokesProps extends IntegrationSpokesGlobalStateProps {
+interface IntegrationSpokesStandardProps {
     source: Source;
     onSpokesSaved?(): void;
+}
+
+interface IntegrationSpokesProps extends IntegrationSpokesGlobalStateProps, IntegrationSpokesStandardProps {
 }
 
 interface IntegrationSpokesState {
@@ -58,6 +61,10 @@ function getResource(state: IntegrationSpokesState): SpokesService.HTTP | Spokes
     } else if (state.showPage === "lambda") {
         return { awsAccessKey: state.iamAccessKey, awsSecretKey: state.iamSecretKey, lambdaARN: state.arn };
     }
+}
+
+function mergeProps(stateProps: IntegrationSpokesGlobalStateProps, dispatchProps: any, parentProps: IntegrationSpokesStandardProps): IntegrationSpokesProps {
+    return { ...parentProps, ...dispatchProps, ...stateProps };
 }
 
 export class IntegrationSpokes extends CancelableComponent<IntegrationSpokesProps, IntegrationSpokesState> {
@@ -98,10 +105,19 @@ export class IntegrationSpokes extends CancelableComponent<IntegrationSpokesProp
         const { enableLiveDebugging } = this.state;
         const resource = getResource(this.state);
 
+        console.info("Saving");
+        console.log(user);
+        console.log(source);
+        console.log(resource);
+        console.log(enableLiveDebugging);
         this.resolve(SpokesService.savePipe(user, source, resource, enableLiveDebugging))
             .then(function (spoke: Spoke) {
+                console.info("Spoke saved.");
+                console.log(spoke);
                 onSpokesSaved();
                 return spoke;
+            }).catch(function(err: Error) {
+                console.error(err);
             });
     }
 
@@ -157,4 +173,5 @@ export class IntegrationSpokes extends CancelableComponent<IntegrationSpokesProp
 export default connect(
     mapStateToProps,
     mapDispatchToProps,
+    mergeProps
 )(IntegrationSpokes);

--- a/src/pages/integration/IntegrationSpokes.tsx
+++ b/src/pages/integration/IntegrationSpokes.tsx
@@ -129,14 +129,13 @@ export class IntegrationSpokes extends CancelableComponent<IntegrationSpokesProp
                 saveDisabled = !validateUrl(others.url);
                 break;
             case "lambda":
-                saveDisabled = others.arn === undefined || others.iamAccessKey === undefined || others.iamSecretKey === undefined;
+                saveDisabled = !(others.arn && others.iamAccessKey && others.iamSecretKey);
                 break;
             default:
                 // We're apparently on something we don't know exists so don't let them go further.
                 saveDisabled = true;
         }
-        console.log(others);
-        console.log(saveDisabled);
+
         return (
             <Grid>
                 <Cell col={3} />

--- a/src/pages/integration/IntegrationSpokes.tsx
+++ b/src/pages/integration/IntegrationSpokes.tsx
@@ -193,6 +193,6 @@ export default connect(
 
 function validateUrl(check?: string): boolean {
     // We're not going to go crazy here.
-    const regex = /^(https?:\/\/).*/;
+    const regex = /^(https?:\/\/).+/;
     return regex.test(check);
 }

--- a/src/pages/integration/IntegrationSpokes.tsx
+++ b/src/pages/integration/IntegrationSpokes.tsx
@@ -4,10 +4,13 @@ import { Button } from "react-toolbox/lib/button";
 import Checkbox from "react-toolbox/lib/checkbox";
 import Dropdown from "react-toolbox/lib/dropdown";
 
+import { Cell, Grid } from "../../components/Grid";
 import IntegrationSpokesSwapper, { PAGE } from "./IntegrationSpokesSwapper";
 
 const DropdownTheme = require("./themes/dropdown.scss");
 const InputTheme = require("./themes/input.scss");
+const CheckboxTheme = require("./themes/checkbox.scss");
+const ButtonTheme = require("./themes/button.scss");
 
 interface DropdownValue {
     value: PAGE;
@@ -29,7 +32,7 @@ interface IntegrationSpokesState {
 
 export class IntegrationSpokes extends React.Component<IntegrationSpokesProps, IntegrationSpokesState> {
 
-    static PAGES: DropdownValue[] = [ { value: "http", label: "HTTP" }, { value: "lambda", label: "Lambda" } ];
+    static PAGES: DropdownValue[] = [{ value: "http", label: "HTTP" }, { value: "lambda", label: "Lambda" }];
 
     constructor(props: IntegrationSpokesProps) {
         super(props);
@@ -67,30 +70,48 @@ export class IntegrationSpokes extends React.Component<IntegrationSpokesProps, I
     render() {
         const { showPage, enableLiveDebugging, ...others } = this.state;
         return (
-            <div>
-                <p>The HTTP SDK proxies traffic to your service (either HTTP or Lambda) via our Spokes.</p>
-                <p>
-                    To use it, simply select your service type, then enter your URL or ARN:
-                </p>
-                <Dropdown
-                    theme={DropdownTheme}
-                    source={IntegrationSpokes.PAGES}
-                    value={showPage}
-                    onChange={this.handleSourceSwap}
-                 />
-                <IntegrationSpokesSwapper
-                    theme={InputTheme}
-                    showPage={showPage}
-                    onChange={this.handleSwapperChange}
-                    {...others} />
-                <Checkbox
-                    label={"Enable Live Debugging"}
-                    checked={enableLiveDebugging}
-                    onChange={this.handleCheckChange} />
-                <Button
-                    label="Save"
-                    onClick={this.handleSave} />
-            </div>
+            <Grid>
+                <Cell col={3} />
+                <Cell col={12}>
+                    <p>The HTTP SDK proxies traffic to your service (either HTTP or Lambda) via our Spokes.</p>
+                    <p>To use it, simply select your service type, then enter your URL or ARN:</p>
+                </Cell>
+                <Cell col={3}>
+                    <Dropdown
+                        theme={DropdownTheme}
+                        source={IntegrationSpokes.PAGES}
+                        value={showPage}
+                        onChange={this.handleSourceSwap}
+                    />
+                </Cell>
+                <Cell col={9}/>
+                <Cell col={6}>
+                    <IntegrationSpokesSwapper
+                        theme={InputTheme}
+                        showPage={showPage}
+                        onChange={this.handleSwapperChange}
+                        {...others} />
+                </Cell>
+                <Cell col={6}/>
+                <Cell col={3}>
+                    <Checkbox
+                        theme={CheckboxTheme}
+                        label={"Enable Live Debugging"}
+                        checked={enableLiveDebugging}
+                        onChange={this.handleCheckChange} />
+                </Cell>
+                <Cell col={9}/>
+                <Cell col={1}>
+                    <Button
+                        theme={ButtonTheme}
+                        accent
+                        raised
+                        label="Save"
+                        onClick={this.handleSave} />
+
+                </Cell>
+                <Cell col={3} />
+            </Grid >
         );
     }
 }

--- a/src/pages/integration/IntegrationSpokes.tsx
+++ b/src/pages/integration/IntegrationSpokes.tsx
@@ -7,6 +7,7 @@ import Dropdown from "react-toolbox/lib/dropdown";
 import IntegrationSpokesSwapper, { PAGE } from "./IntegrationSpokesSwapper";
 
 const DropdownTheme = require("./themes/dropdown.scss");
+const InputTheme = require("./themes/input.scss");
 
 interface DropdownValue {
     value: PAGE;
@@ -78,6 +79,7 @@ export class IntegrationSpokes extends React.Component<IntegrationSpokesProps, I
                     onChange={this.handleSourceSwap}
                  />
                 <IntegrationSpokesSwapper
+                    theme={InputTheme}
                     showPage={showPage}
                     onChange={this.handleSwapperChange}
                     {...others} />

--- a/src/pages/integration/IntegrationSpokes.tsx
+++ b/src/pages/integration/IntegrationSpokes.tsx
@@ -44,7 +44,7 @@ interface IntegrationSpokesProps extends IntegrationSpokesGlobalStateProps, Inte
 
 interface IntegrationSpokesState {
     showPage: PAGE;
-    enableLiveDebugging: boolean;
+    proxy: boolean;
     message?: Message;
     url?: string;
     lambdaARN?: string;
@@ -109,7 +109,7 @@ export class IntegrationSpokes extends CancelableComponent<IntegrationSpokesProp
         this.state = {
             showPage: IntegrationSpokes.PAGES[0].value,
             message: { style: IntegrationSpokes.DEFAULT_MESSAGE_STYLE, message: "" },
-            enableLiveDebugging: false
+            proxy: false
         };
     }
 
@@ -122,7 +122,7 @@ export class IntegrationSpokes extends CancelableComponent<IntegrationSpokesProp
     }
 
     handleCheckChange(value: boolean) {
-        this.setState({ enableLiveDebugging: value } as IntegrationSpokesState);
+        this.setState({ proxy: value } as IntegrationSpokesState);
     }
 
     handleSwapperChange(key: "url"| "lambdaARN" | "awsAccessKey" | "awsSecretKey", value: string) {
@@ -133,11 +133,11 @@ export class IntegrationSpokes extends CancelableComponent<IntegrationSpokesProp
 
     handleSave() {
         const { user, source, onSpokesSaved } = this.props;
-        const { enableLiveDebugging } = this.state;
+        const { proxy } = this.state;
         const resource = getResource(this.state);
 
         this.setState({ message: { style: IntegrationSpokes.STANDARD_MESSAGE_STYLE, message: "Saving..." } } as IntegrationSpokesState);
-        this.resolve(SpokesService.savePipe(user, source, resource, enableLiveDebugging)
+        this.resolve(SpokesService.savePipe(user, source, resource, proxy)
             .then(function (spoke: Spoke) {
                 onSpokesSaved();
                 return { style: IntegrationSpokes.STANDARD_MESSAGE_STYLE, message: "Spoke has been saved." };
@@ -154,16 +154,16 @@ export class IntegrationSpokes extends CancelableComponent<IntegrationSpokesProp
 
         this.resolve(SpokesService.fetchPipe(user, source)
             .then((spoke: Spoke) => {
-                console.log(spoke);
                 const { http, lambda } = spoke;
+                const proxy = { proxy: spoke.proxy };
                 const httpObj = (http) ? http : { url: undefined };
                 const lambdaObj = (lambda) ? lambda : { lambdaARN: undefined, awsAccessKey: undefined, awsSecretKey: undefined };
-                this.setState({ ...httpObj, ...lambdaObj } as IntegrationSpokesState);
+                this.setState({...proxy, ...httpObj, ...lambdaObj } as IntegrationSpokesState);
             }));
     }
 
     render() {
-        const { showPage, enableLiveDebugging, message, ...others } = this.state;
+        const { showPage, proxy, message, ...others } = this.state;
         let saveDisabled: boolean;
         switch (showPage) {
             case "http":
@@ -205,7 +205,7 @@ export class IntegrationSpokes extends CancelableComponent<IntegrationSpokesProp
                     <Checkbox
                         theme={CheckboxTheme}
                         label={"Enable Live Debugging"}
-                        checked={enableLiveDebugging}
+                        checked={proxy}
                         onChange={this.handleCheckChange} />
                 </Cell>
                 <Cell col={9} />

--- a/src/pages/integration/IntegrationSpokes.tsx
+++ b/src/pages/integration/IntegrationSpokes.tsx
@@ -85,7 +85,7 @@ export class IntegrationSpokes extends CancelableComponent<IntegrationSpokesProp
     static PAGES: DropdownValue[] = [{ value: "http", label: "HTTP" }, { value: "lambda", label: "Lambda" }];
 
     static DEFAULT_MESSAGE_STYLE: React.CSSProperties = {
-        visibility: false
+        visibility: "hidden"
     };
 
     static STANDARD_MESSAGE_STYLE: React.CSSProperties = {

--- a/src/pages/integration/IntegrationSpokes.tsx
+++ b/src/pages/integration/IntegrationSpokes.tsx
@@ -1,4 +1,3 @@
-import * as Bluebird from "bluebird";
 import * as React from "react";
 import { connect } from "react-redux";
 
@@ -6,6 +5,7 @@ import { Button } from "react-toolbox/lib/button";
 import Checkbox from "react-toolbox/lib/checkbox";
 import Dropdown from "react-toolbox/lib/dropdown";
 
+import { CancelableComponent } from "../../components/CancelableComponent";
 import { Cell, Grid } from "../../components/Grid";
 import Source from "../../models/source";
 import Spoke from "../../models/spoke";
@@ -60,11 +60,9 @@ function getResource(state: IntegrationSpokesState): SpokesService.HTTP | Spokes
     }
 }
 
-export class IntegrationSpokes extends React.Component<IntegrationSpokesProps, IntegrationSpokesState> {
+export class IntegrationSpokes extends CancelableComponent<IntegrationSpokesProps, IntegrationSpokesState> {
 
     static PAGES: DropdownValue[] = [{ value: "http", label: "HTTP" }, { value: "lambda", label: "Lambda" }];
-
-    savingPromise: Bluebird<Spoke>;
 
     constructor(props: IntegrationSpokesProps) {
         super(props);
@@ -78,12 +76,6 @@ export class IntegrationSpokes extends React.Component<IntegrationSpokesProps, I
             showPage: IntegrationSpokes.PAGES[0].value,
             enableLiveDebugging: false
         };
-    }
-
-    componentWillUnmount() {
-        if (this.savingPromise) {
-            this.savingPromise.cancel();
-        }
     }
 
     handleSourceSwap(value: PAGE) {
@@ -106,8 +98,7 @@ export class IntegrationSpokes extends React.Component<IntegrationSpokesProps, I
         const { enableLiveDebugging } = this.state;
         const resource = getResource(this.state);
 
-        this.savingPromise = Bluebird
-            .resolve(SpokesService.savePipe(user, source, resource, enableLiveDebugging))
+        this.resolve(SpokesService.savePipe(user, source, resource, enableLiveDebugging))
             .then(function (spoke: Spoke) {
                 onSpokesSaved();
                 return spoke;

--- a/src/pages/integration/IntegrationSpokes.tsx
+++ b/src/pages/integration/IntegrationSpokes.tsx
@@ -1,4 +1,31 @@
-// import * as React from "react";
+import * as React from "react";
 
-// import IntegrationHttp from "./IntegrationHttp";
-// import
+import IntegrationSpokesSwapper from "./IntegrationSpokesSwapper";
+
+interface IntegrationSpokesProps {
+    saveSpokes?(): void;
+}
+
+interface IntegrationSpokesState {
+    showPage: "http" | "lambda";
+    url: string;
+    iamAccessKey: string;
+    iamSecretKey: string;
+}
+
+export class IntegrationSpokes extends React.Component<IntegrationSpokesProps, IntegrationSpokesState> {
+
+    render() {
+        const { ...others } = this.state;
+        return (
+            <div>
+                <span>The HTTP SDK proxies traffic to your service (either HTTP or Lambda) via our Spokes.</span>
+                <span>To use it, simply select your service type, then enter your URL or ARN:</span>
+                <IntegrationSpokesSwapper
+                    {...others} />
+            </div>
+        );
+    }
+}
+
+export default IntegrationSpokes;

--- a/src/pages/integration/IntegrationSpokes.tsx
+++ b/src/pages/integration/IntegrationSpokes.tsx
@@ -12,6 +12,7 @@ import Spoke from "../../models/spoke";
 import User from "../../models/user";
 import { State } from "../../reducers";
 import SpokesService from "../../services/spokes";
+import Noop from "../../utils/Noop";
 import IntegrationSpokesSwapper, { PAGE } from "./IntegrationSpokesSwapper";
 
 const DropdownTheme = require("./themes/dropdown.scss");
@@ -75,6 +76,12 @@ function mergeProps(stateProps: IntegrationSpokesGlobalStateProps, dispatchProps
 
 export class IntegrationSpokes extends CancelableComponent<IntegrationSpokesProps, IntegrationSpokesState> {
 
+    static defaultProps: IntegrationSpokesProps = {
+        user: undefined,
+        source: undefined,
+        onSpokesSaved: Noop,
+    };
+
     static PAGES: DropdownValue[] = [{ value: "http", label: "HTTP" }, { value: "lambda", label: "Lambda" }];
 
     static DEFAULT_MESSAGE_STYLE: React.CSSProperties = {
@@ -131,6 +138,7 @@ export class IntegrationSpokes extends CancelableComponent<IntegrationSpokesProp
         console.log(source);
         console.log(resource);
         console.log(enableLiveDebugging);
+        this.setState({ message: { style: IntegrationSpokes.STANDARD_MESSAGE_STYLE, message: "Saving..." }} as IntegrationSpokesState);
         this.resolve(SpokesService.savePipe(user, source, resource, enableLiveDebugging)
             .then(function (spoke: Spoke) {
                 console.info("Spoke saved.");
@@ -192,7 +200,7 @@ export class IntegrationSpokes extends CancelableComponent<IntegrationSpokesProp
                         onChange={this.handleCheckChange} />
                 </Cell>
                 <Cell col={9} />
-                <Cell col={1}>
+                <Cell col={2}>
                     <Button
                         theme={ButtonTheme}
                         accent
@@ -200,7 +208,7 @@ export class IntegrationSpokes extends CancelableComponent<IntegrationSpokesProp
                         disabled={saveDisabled}
                         label="Save"
                         onClick={this.handleSave} />
-                    <span style={message.style}>{message.message}</span>
+                    <p style={message.style}>{message.message}</p>
                 </Cell>
                 <Cell col={3} />
             </Grid >

--- a/src/pages/integration/IntegrationSpokes.tsx
+++ b/src/pages/integration/IntegrationSpokes.tsx
@@ -1,0 +1,4 @@
+// import * as React from "react";
+
+// import IntegrationHttp from "./IntegrationHttp";
+// import

--- a/src/pages/integration/IntegrationSpokes.tsx
+++ b/src/pages/integration/IntegrationSpokes.tsx
@@ -19,6 +19,7 @@ interface IntegrationSpokesState {
     showPage: PAGE;
     enableLiveDebugging: boolean;
     url?: string;
+    arn?: string;
     iamAccessKey?: string;
     iamSecretKey?: string;
 }
@@ -33,6 +34,7 @@ export class IntegrationSpokes extends React.Component<IntegrationSpokesProps, I
         this.handleSourceSwap = this.handleSourceSwap.bind(this);
         this.handleCheckChange = this.handleCheckChange.bind(this);
         this.handleSave = this.handleSave.bind(this);
+        this.handleSwapperChange = this.handleSwapperChange.bind(this);
 
         this.state = {
             showPage: IntegrationSpokes.PAGES[0].value,
@@ -46,6 +48,13 @@ export class IntegrationSpokes extends React.Component<IntegrationSpokesProps, I
 
     handleCheckChange(value: boolean) {
         this.setState({ enableLiveDebugging: value } as IntegrationSpokesState);
+    }
+
+    handleSwapperChange(key: "url" | "iamAccessKey" | "iamSecretKey" | "arn", value: string) {
+        let newObj = {} as any;
+        newObj[key] = value;
+        console.log(newObj);
+        this.setState(newObj);
     }
 
     handleSave() {
@@ -67,6 +76,7 @@ export class IntegrationSpokes extends React.Component<IntegrationSpokesProps, I
                  />
                 <IntegrationSpokesSwapper
                     showPage={showPage}
+                    onChange={this.handleSwapperChange}
                     {...others} />
                 <Checkbox
                     label={"Enable Live Debugging"}

--- a/src/pages/integration/IntegrationSpokes.tsx
+++ b/src/pages/integration/IntegrationSpokes.tsx
@@ -116,13 +116,27 @@ export class IntegrationSpokes extends CancelableComponent<IntegrationSpokesProp
                 console.log(spoke);
                 onSpokesSaved();
                 return spoke;
-            }).catch(function(err: Error) {
+            }).catch(function (err: Error) {
                 console.error(err);
             });
     }
 
     render() {
         const { showPage, enableLiveDebugging, ...others } = this.state;
+        let saveDisabled: boolean;
+        switch (showPage) {
+            case "http":
+                saveDisabled = others.url === undefined;
+                break;
+            case "lambda":
+                saveDisabled = others.arn === undefined || others.iamAccessKey === undefined || others.iamSecretKey === undefined;
+                break;
+            default:
+                // We're apparently on something we don't know exists so don't let them go further.
+                saveDisabled = true;
+        }
+        console.log(others);
+        console.log(saveDisabled);
         return (
             <Grid>
                 <Cell col={3} />
@@ -160,6 +174,7 @@ export class IntegrationSpokes extends CancelableComponent<IntegrationSpokesProp
                         theme={ButtonTheme}
                         accent
                         raised
+                        disabled={saveDisabled}
                         label="Save"
                         onClick={this.handleSave} />
 

--- a/src/pages/integration/IntegrationSpokes.tsx
+++ b/src/pages/integration/IntegrationSpokes.tsx
@@ -126,7 +126,7 @@ export class IntegrationSpokes extends CancelableComponent<IntegrationSpokesProp
         let saveDisabled: boolean;
         switch (showPage) {
             case "http":
-                saveDisabled = others.url === undefined;
+                saveDisabled = !validateUrl(others.url);
                 break;
             case "lambda":
                 saveDisabled = others.arn === undefined || others.iamAccessKey === undefined || others.iamSecretKey === undefined;
@@ -190,3 +190,9 @@ export default connect(
     mapDispatchToProps,
     mergeProps
 )(IntegrationSpokes);
+
+function validateUrl(check?: string): boolean {
+    // We're not going to go crazy here.
+    const regex = /^(https?:\/\/).*/;
+    return regex.test(check);
+}

--- a/src/pages/integration/IntegrationSpokes.tsx
+++ b/src/pages/integration/IntegrationSpokes.tsx
@@ -6,6 +6,8 @@ import Dropdown from "react-toolbox/lib/dropdown";
 
 import IntegrationSpokesSwapper, { PAGE } from "./IntegrationSpokesSwapper";
 
+const DropdownTheme = require("./themes/dropdown.scss");
+
 interface DropdownValue {
     value: PAGE;
     label: string;
@@ -70,6 +72,7 @@ export class IntegrationSpokes extends React.Component<IntegrationSpokesProps, I
                     To use it, simply select your service type, then enter your URL or ARN:
                 </p>
                 <Dropdown
+                    theme={DropdownTheme}
                     source={IntegrationSpokes.PAGES}
                     value={showPage}
                     onChange={this.handleSourceSwap}

--- a/src/pages/integration/IntegrationSpokes.tsx
+++ b/src/pages/integration/IntegrationSpokes.tsx
@@ -1,28 +1,80 @@
 import * as React from "react";
 
-import IntegrationSpokesSwapper from "./IntegrationSpokesSwapper";
+import { Button } from "react-toolbox/lib/button";
+import Checkbox from "react-toolbox/lib/checkbox";
+import Dropdown from "react-toolbox/lib/dropdown";
+
+import IntegrationSpokesSwapper, { PAGE } from "./IntegrationSpokesSwapper";
+
+interface DropdownValue {
+    value: PAGE;
+    label: string;
+}
 
 interface IntegrationSpokesProps {
     saveSpokes?(): void;
 }
 
 interface IntegrationSpokesState {
-    showPage: "http" | "lambda";
-    url: string;
-    iamAccessKey: string;
-    iamSecretKey: string;
+    showPage: PAGE;
+    enableLiveDebugging: boolean;
+    url?: string;
+    iamAccessKey?: string;
+    iamSecretKey?: string;
 }
 
 export class IntegrationSpokes extends React.Component<IntegrationSpokesProps, IntegrationSpokesState> {
 
+    static PAGES: DropdownValue[] = [ { value: "http", label: "HTTP" }, { value: "lambda", label: "Lambda" } ];
+
+    constructor(props: IntegrationSpokesProps) {
+        super(props);
+
+        this.handleSourceSwap = this.handleSourceSwap.bind(this);
+        this.handleCheckChange = this.handleCheckChange.bind(this);
+        this.handleSave = this.handleSave.bind(this);
+
+        this.state = {
+            showPage: IntegrationSpokes.PAGES[0].value,
+            enableLiveDebugging: false
+        };
+    }
+
+    handleSourceSwap(value: PAGE) {
+        this.setState({ showPage: value } as IntegrationSpokesState);
+    }
+
+    handleCheckChange(value: boolean) {
+        this.setState({ enableLiveDebugging: value } as IntegrationSpokesState);
+    }
+
+    handleSave() {
+        console.info("Saving");
+    }
+
     render() {
-        const { ...others } = this.state;
+        const { showPage, enableLiveDebugging, ...others } = this.state;
         return (
             <div>
-                <span>The HTTP SDK proxies traffic to your service (either HTTP or Lambda) via our Spokes.</span>
-                <span>To use it, simply select your service type, then enter your URL or ARN:</span>
+                <p>The HTTP SDK proxies traffic to your service (either HTTP or Lambda) via our Spokes.</p>
+                <p>
+                    To use it, simply select your service type, then enter your URL or ARN:
+                </p>
+                <Dropdown
+                    source={IntegrationSpokes.PAGES}
+                    value={showPage}
+                    onChange={this.handleSourceSwap}
+                 />
                 <IntegrationSpokesSwapper
+                    showPage={showPage}
                     {...others} />
+                <Checkbox
+                    label={"Enable Live Debugging"}
+                    checked={enableLiveDebugging}
+                    onChange={this.handleCheckChange} />
+                <Button
+                    label="Save"
+                    onClick={this.handleSave} />
             </div>
         );
     }

--- a/src/pages/integration/IntegrationSpokesSwapper.test.tsx
+++ b/src/pages/integration/IntegrationSpokesSwapper.test.tsx
@@ -30,9 +30,9 @@ describe("Spokes Swapper", function () {
                 wrapper = shallow(<IntegrationSpokesSwapper
                     theme={"TestTheme"}
                     showPage="http"
-                    arn="TestArn"
-                    iamAccessKey="TestAccessKey"
-                    iamSecretKey="TestSecretKey"
+                    lambdaARN="TestArn"
+                    awsAccessKey="TestAccessKey"
+                    awsSecretKey="TestSecretKey"
                     url="TestUrl"
                     onChange={onChange}
                 />);
@@ -66,9 +66,9 @@ describe("Spokes Swapper", function () {
                 wrapper = shallow(<IntegrationSpokesSwapper
                     theme="TestTheme"
                     showPage="lambda"
-                    arn="TestArn"
-                    iamAccessKey="TestAccessKey"
-                    iamSecretKey="TestSecretKey"
+                    lambdaARN="TestArn"
+                    awsAccessKey="TestAccessKey"
+                    awsSecretKey="TestSecretKey"
                     url="TestUrl"
                     onChange={onChange}
                 />);
@@ -85,16 +85,16 @@ describe("Spokes Swapper", function () {
             it("Tests the lambda page gets the appropriate props.", function() {
                 const lambdaWrapper = wrapper.find(IntegrationLambda).at(0);
                 expect(lambdaWrapper).to.have.prop("theme", "TestTheme");
-                expect(lambdaWrapper).to.have.prop("arn", "TestArn");
-                expect(lambdaWrapper).to.have.prop("iamAccessKey", "TestAccessKey");
-                expect(lambdaWrapper).to.have.prop("iamSecretKey", "TestSecretKey");
+                expect(lambdaWrapper).to.have.prop("lambdaARN", "TestArn");
+                expect(lambdaWrapper).to.have.prop("awsAccessKey", "TestAccessKey");
+                expect(lambdaWrapper).to.have.prop("awsSecretKey", "TestSecretKey");
             });
 
             it("Tests the http page will pass up the arn change.", function() {
                 const lambdaWrapper = wrapper.find(IntegrationLambda).at(0);
-                lambdaWrapper.simulate("change", "arn", "New Arn");
+                lambdaWrapper.simulate("change", "lambdaARN", "New Arn");
                 expect(onChange).to.have.been.calledOnce;
-                expect(onChange).to.have.been.calledWith("arn", "New Arn");
+                expect(onChange).to.have.been.calledWith("lambdaARN", "New Arn");
             });
         });
     });

--- a/src/pages/integration/IntegrationSpokesSwapper.test.tsx
+++ b/src/pages/integration/IntegrationSpokesSwapper.test.tsx
@@ -54,7 +54,7 @@ describe("IntegrationPage", function () {
                 const httpWrapper = wrapper.find(IntegrationHttp).at(0);
                 httpWrapper.simulate("urlChange", "New Url");
                 expect(onChange).to.have.been.calledOnce;
-                expect(onChange).to.have.been.calledWith("http", "New Url");
+                expect(onChange).to.have.been.calledWith("url", "New Url");
             });
         });
 

--- a/src/pages/integration/IntegrationSpokesSwapper.test.tsx
+++ b/src/pages/integration/IntegrationSpokesSwapper.test.tsx
@@ -11,7 +11,7 @@ import IntegrationSpokesSwapper from "./IntegrationSpokesSwapper";
 chai.use(sinonChai);
 const expect = chai.expect;
 
-describe("IntegrationPage", function () {
+describe("Spokes Swapper", function () {
     describe("Renders", function () {
         let wrapper: ShallowWrapper<any, any>;
         let onChange: Sinon.SinonStub;
@@ -28,6 +28,7 @@ describe("IntegrationPage", function () {
 
             before(function() {
                 wrapper = shallow(<IntegrationSpokesSwapper
+                    theme={"TestTheme"}
                     showPage="http"
                     arn="TestArn"
                     iamAccessKey="TestAccessKey"
@@ -48,6 +49,7 @@ describe("IntegrationPage", function () {
             it("Tests the http page gets the appropriate props.", function() {
                 const httpWrapper = wrapper.find(IntegrationHttp).at(0);
                 expect(httpWrapper).to.have.prop("url", "TestUrl");
+                expect(httpWrapper).to.have.prop("theme", "TestTheme");
             });
 
             it("Tests the http page will pass up the url change..", function() {
@@ -62,6 +64,7 @@ describe("IntegrationPage", function () {
 
             before(function() {
                 wrapper = shallow(<IntegrationSpokesSwapper
+                    theme="TestTheme"
                     showPage="lambda"
                     arn="TestArn"
                     iamAccessKey="TestAccessKey"
@@ -79,8 +82,9 @@ describe("IntegrationPage", function () {
                 expect(wrapper.find(IntegrationLambda)).to.have.length(1);
             });
 
-            it("Tests the http page gets the appropriate props.", function() {
+            it("Tests the lambda page gets the appropriate props.", function() {
                 const lambdaWrapper = wrapper.find(IntegrationLambda).at(0);
+                expect(lambdaWrapper).to.have.prop("theme", "TestTheme");
                 expect(lambdaWrapper).to.have.prop("arn", "TestArn");
                 expect(lambdaWrapper).to.have.prop("iamAccessKey", "TestAccessKey");
                 expect(lambdaWrapper).to.have.prop("iamSecretKey", "TestSecretKey");

--- a/src/pages/integration/IntegrationSpokesSwapper.test.tsx
+++ b/src/pages/integration/IntegrationSpokesSwapper.test.tsx
@@ -1,0 +1,97 @@
+import * as chai from "chai";
+import { shallow, ShallowWrapper } from "enzyme";
+import * as React from "react";
+import * as sinon from "sinon";
+import * as sinonChai from "sinon-chai";
+
+import IntegrationHttp from "./IntegrationHttp";
+import IntegrationLambda from "./IntegrationLambda";
+import IntegrationSpokesSwapper from "./IntegrationSpokesSwapper";
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe("IntegrationPage", function () {
+    describe("Renders", function () {
+        let wrapper: ShallowWrapper<any, any>;
+        let onChange: Sinon.SinonStub;
+
+        before(function() {
+            onChange = sinon.stub();
+        });
+
+        afterEach(function() {
+            onChange.reset();
+        });
+
+        describe("Http page", function () {
+
+            before(function() {
+                wrapper = shallow(<IntegrationSpokesSwapper
+                    showPage="http"
+                    arn="TestArn"
+                    iamAccessKey="TestAccessKey"
+                    iamSecretKey="TestSecretKey"
+                    url="TestUrl"
+                    onChange={onChange}
+                />);
+            });
+
+            it("Tests the http page exists.", function () {
+                expect(wrapper.find(IntegrationHttp)).to.have.length(1);
+            });
+
+            it("Tests that the lambda page does not exist.", function() {
+                expect(wrapper.find(IntegrationLambda)).to.have.length(0);
+            });
+
+            it("Tests the http page gets the appropriate props.", function() {
+                const httpWrapper = wrapper.find(IntegrationHttp).at(0);
+                expect(httpWrapper).to.have.prop("url", "TestUrl");
+            });
+
+            it("Tests the http page will pass up the url change..", function() {
+                const httpWrapper = wrapper.find(IntegrationHttp).at(0);
+                httpWrapper.simulate("urlChange", "New Url");
+                expect(onChange).to.have.been.calledOnce;
+                expect(onChange).to.have.been.calledWith("http", "New Url");
+            });
+        });
+
+        describe("Lambda page", function () {
+
+            before(function() {
+                wrapper = shallow(<IntegrationSpokesSwapper
+                    showPage="lambda"
+                    arn="TestArn"
+                    iamAccessKey="TestAccessKey"
+                    iamSecretKey="TestSecretKey"
+                    url="TestUrl"
+                    onChange={onChange}
+                />);
+            });
+
+            it("Tests the http page does not exist.", function () {
+                expect(wrapper.find(IntegrationHttp)).to.have.length(0);
+            });
+
+            it("Tests that the lambda page exists.", function() {
+                expect(wrapper.find(IntegrationLambda)).to.have.length(1);
+            });
+
+            it("Tests the http page gets the appropriate props.", function() {
+                const lambdaWrapper = wrapper.find(IntegrationLambda).at(0);
+                expect(lambdaWrapper).to.have.prop("arn", "TestArn");
+                expect(lambdaWrapper).to.have.prop("iamAccessKey", "TestAccessKey");
+                expect(lambdaWrapper).to.have.prop("iamSecretKey", "TestSecretKey");
+            });
+
+            it("Tests the http page will pass up the arn change.", function() {
+                const lambdaWrapper = wrapper.find(IntegrationLambda).at(0);
+                lambdaWrapper.simulate("change", "arn", "New Arn");
+                expect(onChange).to.have.been.calledOnce;
+                expect(onChange).to.have.been.calledWith("arn", "New Arn");
+            });
+        });
+    });
+});

--- a/src/pages/integration/IntegrationSpokesSwapper.test.tsx
+++ b/src/pages/integration/IntegrationSpokesSwapper.test.tsx
@@ -6,7 +6,7 @@ import * as sinonChai from "sinon-chai";
 
 import IntegrationHttp from "./IntegrationHttp";
 import IntegrationLambda from "./IntegrationLambda";
-import IntegrationSpokesSwapper from "./IntegrationSpokesSwapper";
+import IntegrationSpokesSwapper, { PAGE } from "./IntegrationSpokesSwapper";
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -16,17 +16,17 @@ describe("Spokes Swapper", function () {
         let wrapper: ShallowWrapper<any, any>;
         let onChange: Sinon.SinonStub;
 
-        before(function() {
+        before(function () {
             onChange = sinon.stub();
         });
 
-        afterEach(function() {
+        afterEach(function () {
             onChange.reset();
         });
 
         describe("Http page", function () {
 
-            before(function() {
+            before(function () {
                 wrapper = shallow(<IntegrationSpokesSwapper
                     theme={"TestTheme"}
                     showPage="http"
@@ -42,17 +42,17 @@ describe("Spokes Swapper", function () {
                 expect(wrapper.find(IntegrationHttp)).to.have.length(1);
             });
 
-            it("Tests that the lambda page does not exist.", function() {
+            it("Tests that the lambda page does not exist.", function () {
                 expect(wrapper.find(IntegrationLambda)).to.have.length(0);
             });
 
-            it("Tests the http page gets the appropriate props.", function() {
+            it("Tests the http page gets the appropriate props.", function () {
                 const httpWrapper = wrapper.find(IntegrationHttp).at(0);
                 expect(httpWrapper).to.have.prop("url", "TestUrl");
                 expect(httpWrapper).to.have.prop("theme", "TestTheme");
             });
 
-            it("Tests the http page will pass up the url change..", function() {
+            it("Tests the http page will pass up the url change..", function () {
                 const httpWrapper = wrapper.find(IntegrationHttp).at(0);
                 httpWrapper.simulate("urlChange", "New Url");
                 expect(onChange).to.have.been.calledOnce;
@@ -62,7 +62,7 @@ describe("Spokes Swapper", function () {
 
         describe("Lambda page", function () {
 
-            before(function() {
+            before(function () {
                 wrapper = shallow(<IntegrationSpokesSwapper
                     theme="TestTheme"
                     showPage="lambda"
@@ -78,11 +78,11 @@ describe("Spokes Swapper", function () {
                 expect(wrapper.find(IntegrationHttp)).to.have.length(0);
             });
 
-            it("Tests that the lambda page exists.", function() {
+            it("Tests that the lambda page exists.", function () {
                 expect(wrapper.find(IntegrationLambda)).to.have.length(1);
             });
 
-            it("Tests the lambda page gets the appropriate props.", function() {
+            it("Tests the lambda page gets the appropriate props.", function () {
                 const lambdaWrapper = wrapper.find(IntegrationLambda).at(0);
                 expect(lambdaWrapper).to.have.prop("theme", "TestTheme");
                 expect(lambdaWrapper).to.have.prop("lambdaARN", "TestArn");
@@ -90,11 +90,30 @@ describe("Spokes Swapper", function () {
                 expect(lambdaWrapper).to.have.prop("awsSecretKey", "TestSecretKey");
             });
 
-            it("Tests the http page will pass up the arn change.", function() {
+            it("Tests the http page will pass up the arn change.", function () {
                 const lambdaWrapper = wrapper.find(IntegrationLambda).at(0);
                 lambdaWrapper.simulate("change", "lambdaARN", "New Arn");
                 expect(onChange).to.have.been.calledOnce;
                 expect(onChange).to.have.been.calledWith("lambdaARN", "New Arn");
+            });
+        });
+
+        describe("Random page", function () {
+            before(function () {
+                wrapper = shallow(<IntegrationSpokesSwapper
+                    theme="TestTheme"
+                    showPage={"Page that does not exist." as PAGE}
+                    lambdaARN="TestArn"
+                    awsAccessKey="TestAccessKey"
+                    awsSecretKey="TestSecretKey"
+                    url="TestUrl"
+                    onChange={onChange}
+                />);
+            });
+
+            it("Tests that nothing is shown.", function() {
+                expect(wrapper.find(IntegrationLambda)).to.have.length(0);
+                expect(wrapper.find(IntegrationHttp)).to.have.length(0);
             });
         });
     });

--- a/src/pages/integration/IntegrationSpokesSwapper.tsx
+++ b/src/pages/integration/IntegrationSpokesSwapper.tsx
@@ -7,6 +7,7 @@ export type PAGE = "http" | "lambda";
 
 interface IntegrationSpokesSwapperProps {
     showPage: PAGE;
+    theme?: string;
     arn?: string;
     url?: string;
     iamAccessKey?: string;
@@ -34,12 +35,12 @@ export class IntegrationSpokesSwapper extends React.Component<IntegrationSpokesS
     }
 
     render() {
-        const { showPage } = this.props;
+        const { showPage, ...others } = this.props;
         switch (showPage) {
             case "http":
-                return (<IntegrationHttp {...this.props} onUrlChange={this.handleHttpChange} />);
+                return (<IntegrationHttp {...others} onUrlChange={this.handleHttpChange} />);
             case "lambda":
-                return (<IntegrationLambda {...this.props} />);
+                return (<IntegrationLambda {...others} />);
             default:
                 return (<div />);
         }

--- a/src/pages/integration/IntegrationSpokesSwapper.tsx
+++ b/src/pages/integration/IntegrationSpokesSwapper.tsx
@@ -11,7 +11,7 @@ interface IntegrationSpokesSwapperProps {
     url?: string;
     iamAccessKey?: string;
     iamSecretKey?: string;
-    onChange?: (type: "http" | "arn" | "iamAccessKey" | "iamSecretKey", newValue: string) => void;
+    onChange?: (type: "url" | "arn" | "iamAccessKey" | "iamSecretKey", newValue: string) => void;
 }
 
 interface IntegrationSpokesSwapperState {
@@ -29,7 +29,7 @@ export class IntegrationSpokesSwapper extends React.Component<IntegrationSpokesS
     handleHttpChange(value: string) {
         const { onChange } = this.props;
         if (onChange) {
-            onChange("http", value);
+            onChange("url", value);
         }
     }
 

--- a/src/pages/integration/IntegrationSpokesSwapper.tsx
+++ b/src/pages/integration/IntegrationSpokesSwapper.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+
+import IntegrationHttp from "./IntegrationHttp";
+import IntegrationLambda from "./IntegrationLambda";
+
+interface IntegrationSpokesSwapperProps {
+    showPage: "http" | "lambda";
+    arn?: string;
+    url?: string;
+    iamAccessKey?: string;
+    iamSecretKey?: string;
+    onChange?: (type: "http" | "arn" | "iamAccessKey" | "iamSecretKey", newValue: string) => void;
+}
+
+interface IntegrationSpokesSwapperState {
+
+}
+
+export class IntegrationSpokesSwapper extends React.Component<IntegrationSpokesSwapperProps, IntegrationSpokesSwapperState> {
+
+    constructor(props: IntegrationSpokesSwapperProps) {
+        super(props);
+
+        this.handleHttpChange = this.handleHttpChange.bind(this);
+    }
+
+    handleHttpChange(value: string) {
+        const { onChange } = this.props;
+        if (onChange) {
+            onChange("http", value);
+        }
+    }
+
+    render() {
+        const { showPage } = this.props;
+        switch (showPage) {
+            case "http":
+                return (<IntegrationHttp {...this.props} onUrlChange={this.handleHttpChange} />);
+            case "lambda":
+                return (<IntegrationLambda {...this.props} />);
+            default:
+                return (<div />);
+        }
+    }
+}
+
+export default IntegrationSpokesSwapper;

--- a/src/pages/integration/IntegrationSpokesSwapper.tsx
+++ b/src/pages/integration/IntegrationSpokesSwapper.tsx
@@ -3,8 +3,10 @@ import * as React from "react";
 import IntegrationHttp from "./IntegrationHttp";
 import IntegrationLambda from "./IntegrationLambda";
 
+export type PAGE = "http" | "lambda";
+
 interface IntegrationSpokesSwapperProps {
-    showPage: "http" | "lambda";
+    showPage: PAGE;
     arn?: string;
     url?: string;
     iamAccessKey?: string;

--- a/src/pages/integration/IntegrationSpokesSwapper.tsx
+++ b/src/pages/integration/IntegrationSpokesSwapper.tsx
@@ -8,11 +8,11 @@ export type PAGE = "http" | "lambda";
 interface IntegrationSpokesSwapperProps {
     showPage: PAGE;
     theme?: string;
-    arn?: string;
+    lambdaARN?: string;
     url?: string;
-    iamAccessKey?: string;
-    iamSecretKey?: string;
-    onChange?: (type: "url" | "arn" | "iamAccessKey" | "iamSecretKey", newValue: string) => void;
+    awsAccessKey?: string;
+    awsSecretKey?: string;
+    onChange?: (type: "url" | "lambdaARN" | "awsAccessKey" | "awsSecretKey", newValue: string) => void;
 }
 
 interface IntegrationSpokesSwapperState {

--- a/src/pages/integration/IntegrationSpokesSwapper.tsx
+++ b/src/pages/integration/IntegrationSpokesSwapper.tsx
@@ -35,12 +35,12 @@ export class IntegrationSpokesSwapper extends React.Component<IntegrationSpokesS
     }
 
     render() {
-        const { showPage, ...others } = this.props;
+        const { showPage, url, awsAccessKey, awsSecretKey, lambdaARN, ...others } = this.props;
         switch (showPage) {
             case "http":
-                return (<IntegrationHttp {...others} onUrlChange={this.handleHttpChange} />);
+                return (<IntegrationHttp {...others} url={url} onUrlChange={this.handleHttpChange} />);
             case "lambda":
-                return (<IntegrationLambda {...others} />);
+                return (<IntegrationLambda {...others} awsAccessKey={awsAccessKey} awsSecretKey={awsSecretKey} lambdaARN={lambdaARN} />);
             default:
                 return (<div />);
         }

--- a/src/pages/integration/StateIntegrationPage.test.tsx
+++ b/src/pages/integration/StateIntegrationPage.test.tsx
@@ -28,13 +28,13 @@ describe("StateIntegrationPage", function () {
 
         it("Tests the IntegrationPage contains the appropriate props.", function () {
             const page = wrapper.find(IntegrationPage).at(0);
-            expect(page.prop("secretKey")).to.equal("ABC123");
+            expect(page.prop("source")).to.equal(source);
         });
 
         it ("Tests it renders properly on props change to undefined.", function() {
             wrapper.setProps({ source: undefined });
             const page = wrapper.find(IntegrationPage).at(0);
-            expect(page.prop("secretKey")).to.be.undefined;
+            expect(page.prop("source")).to.be.undefined;
         });
 
         it ("Tests it renders properly on props change to a new source.", function() {
@@ -46,7 +46,7 @@ describe("StateIntegrationPage", function () {
             wrapper.setProps({ source: newsource });
 
             const page = wrapper.find(IntegrationPage).at(0);
-            expect(page.prop("secretKey")).to.be.equal("123ABC");
+            expect(page.prop("source")).to.equal(newsource);
         });
     });
 
@@ -71,7 +71,7 @@ describe("StateIntegrationPage", function () {
             wrapper.setProps({ source: newsource });
 
             const page = wrapper.find(IntegrationPage).at(0);
-            expect(page.prop("secretKey")).to.be.equal("123ABC");
+            expect(page.prop("source")).to.equal(newsource);
         });
     });
 });

--- a/src/pages/integration/StateIntegrationPage.tsx
+++ b/src/pages/integration/StateIntegrationPage.tsx
@@ -10,7 +10,6 @@ interface StateIntegrationProps {
 }
 
 interface StateIntegrationState {
-    secretKey: string;
 }
 
 function mapStateToProps(state: State.All) {
@@ -21,22 +20,10 @@ function mapStateToProps(state: State.All) {
 
 export class StateIntegrationPage extends React.Component<StateIntegrationProps, StateIntegrationState> {
 
-    constructor(props: StateIntegrationProps) {
-        super(props);
-
-        this.state = {
-            secretKey: (props.source) ? props.source.secretKey : undefined
-        };
-    }
-
-    componentWillReceiveProps(props: StateIntegrationProps, context: any) {
-        this.state.secretKey = (props.source) ? props.source.secretKey : undefined;
-        this.setState(this.state);
-    }
-
     render() {
+        const { source } = this.props;
         return (
-            <IntegrationPage secretKey={this.state.secretKey} />
+            <IntegrationPage source={source} />
         );
     }
 }

--- a/src/pages/integration/themes/button.scss
+++ b/src/pages/integration/themes/button.scss
@@ -1,0 +1,1 @@
+@import "../../../themes/button_theme.scss";

--- a/src/pages/integration/themes/checkbox.scss
+++ b/src/pages/integration/themes/checkbox.scss
@@ -1,0 +1,1 @@
+@import "../../../themes/checkbox-theme";

--- a/src/pages/integration/themes/dropdown.scss
+++ b/src/pages/integration/themes/dropdown.scss
@@ -1,0 +1,1 @@
+@import "../../../themes/dropdown-dark";

--- a/src/pages/integration/themes/input.scss
+++ b/src/pages/integration/themes/input.scss
@@ -1,1 +1,6 @@
-@import "../../../themes/input";
+@import "../../../themes/input-config";
+
+$input-field-font-size: 1.1em;
+$input-label-font-size: 1.1em;
+
+@import "~react-toolbox/lib/input/theme";

--- a/src/pages/integration/themes/input.scss
+++ b/src/pages/integration/themes/input.scss
@@ -1,0 +1,1 @@
+@import "../../../themes/input";

--- a/src/pages/integration/themes/inputs.scss
+++ b/src/pages/integration/themes/inputs.scss
@@ -1,1 +1,0 @@
-@import "../../../themes/input-light";

--- a/src/pages/integration/themes/inputs.scss
+++ b/src/pages/integration/themes/inputs.scss
@@ -1,0 +1,1 @@
+@import "../../../themes/input-light";

--- a/src/services/source.test.ts
+++ b/src/services/source.test.ts
@@ -143,7 +143,6 @@ describe("Source Service", function () {
             return SourceService.generateSourceId()
                 .then(function (resource: SourceService.SourceName) {
                     expect(resource).to.exist;
-                    console.log(resource);
                     expect(resource.id).to.equal("test-source-bhjas3");
                     expect(resource.secretKey).to.equal("ABC123456");
                 });

--- a/src/services/spokes.test.ts
+++ b/src/services/spokes.test.ts
@@ -80,7 +80,8 @@ describe("Spokes Service", function () {
                 return SpokesService.fetchPipe(user, source)
                     .then(function (payload: Spoke) {
                         const args = fetchMock.lastCall()[1] as RequestInit;
-                        expect(args.headers["x-access-userid"]).to.equal(user.userId);
+                        const header = args.headers as Headers;
+                        expect(header.get("x-access-userid")).to.equal(user.userId);
                     });
             });
 
@@ -131,9 +132,10 @@ describe("Spokes Service", function () {
                 return SpokesService.savePipe(user, source, { url: "http:spoke.url/" }, true)
                     .then(function (payload: Spoke) {
                         const args = fetchMock.lastCall()[1] as RequestInit;
+                        const headers = args.headers as Headers;
                         expect(args.method).to.equal("POST");
-                        expect(args.headers["Content-Type"]).to.equal("application/json");
-                        expect(args.headers["x-access-userid"]).to.equal(user.userId);
+                        expect(headers.get("Content-Type")).to.equal("application/json");
+                        expect(headers.get("x-access-userid")).to.equal(user.userId);
                     });
             });
 

--- a/src/services/spokes.test.ts
+++ b/src/services/spokes.test.ts
@@ -80,8 +80,8 @@ describe("Spokes Service", function () {
                 return SpokesService.fetchPipe(user, source)
                     .then(function (payload: Spoke) {
                         const args = fetchMock.lastCall()[1] as RequestInit;
-                        const header = args.headers as Headers;
-                        expect(header.get("x-access-userid")).to.equal(user.userId);
+                        const header = args.headers as any;
+                        expect(header["x-access-userid"]).to.equal(user.userId);
                     });
             });
 
@@ -132,10 +132,10 @@ describe("Spokes Service", function () {
                 return SpokesService.savePipe(user, source, { url: "http:spoke.url/" }, true)
                     .then(function (payload: Spoke) {
                         const args = fetchMock.lastCall()[1] as RequestInit;
-                        const headers = args.headers as Headers;
+                        const headers = args.headers as any;
                         expect(args.method).to.equal("POST");
-                        expect(headers.get("Content-Type")).to.equal("application/json");
-                        expect(headers.get("x-access-userid")).to.equal(user.userId);
+                        expect(headers["Content-Type"]).to.equal("application/json");
+                        expect(headers["x-access-userid"]).to.equal(user.userId);
                     });
             });
 

--- a/src/services/spokes.test.ts
+++ b/src/services/spokes.test.ts
@@ -121,7 +121,7 @@ describe("Spokes Service", function () {
             });
 
             it("Tests the payload is returned upon successful save for lambda.", function () {
-                return SpokesService.savePipe(user, source, { lamdaARN: "testARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" }, true)
+                return SpokesService.savePipe(user, source, { lambdaARN: "testARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" }, true)
                     .then(function (payload: Spoke) {
                         expect(payload).to.exist;
                     });
@@ -166,7 +166,7 @@ describe("Spokes Service", function () {
             });
 
             it("Tests the proper post object was sent by the service is correct for lamdba.", function () {
-                return SpokesService.savePipe(user, source, { lamdaARN: "testARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" }, true)
+                return SpokesService.savePipe(user, source, { lambdaARN: "testARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" }, true)
                     .then(function (payload: Spoke) {
                         const args = fetchMock.lastCall()[1] as RequestInit;
                         const reqObj = JSON.parse(args.body);
@@ -198,7 +198,7 @@ describe("Spokes Service", function () {
             });
 
             it("Tests the Spoke returned by the service is correct for lambda.", function () {
-                return SpokesService.savePipe(user, source, { lamdaARN: "testARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" }, true)
+                return SpokesService.savePipe(user, source, { lambdaARN: "testARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" }, true)
                     .then(function (payload: Spoke) {
                         expect(payload).to.exist;
                         expect(payload.diagnosticKey).to.equal(fetchResponse.diagnosticKey);
@@ -254,7 +254,7 @@ describe("Spokes Service", function () {
 
             it("Tests the promise rejects upon not saved.", function () {
                 let caughtError: Error;
-                return SpokesService.savePipe(user, source, { lamdaARN: "testARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" }, true)
+                return SpokesService.savePipe(user, source, { lambdaARN: "testARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" }, true)
                     .catch(function (err: Error) {
                         caughtError = err;
                     }).then(function() {
@@ -304,7 +304,7 @@ describe("Spokes Service", function () {
 
             it("Tests the promise rejects upon network error.", function () {
                 let caughtError: Error;
-                return SpokesService.savePipe(user, source, { lamdaARN: "testARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" }, true)
+                return SpokesService.savePipe(user, source, { lambdaARN: "testARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" }, true)
                     .catch(function (err: Error) {
                         caughtError = err;
                     }).then(function () {

--- a/src/services/spokes.test.ts
+++ b/src/services/spokes.test.ts
@@ -58,15 +58,34 @@ describe("Spokes Service", function () {
             });
 
             it("Tests the appropriately URL was created.", function () {
-                return SpokesService.fetchPipe(source)
+                return SpokesService.fetchPipe(user, source)
                     .then(function () {
                         const url = BASE_URL + "/pipe/" + source.secretKey;
                         expect(fetchMock.lastUrl()).to.equal(url);
                     });
             });
 
+            it("Tests that an error is thrown when an invalid user is not provided.", function () {
+                const copyUser = { ...user, ...{ userId: undefined } };
+                let caughtError: Error;
+                return SpokesService.fetchPipe(copyUser, source)
+                    .catch(function (err: Error) {
+                        caughtError = err;
+                    }).then(function () {
+                        expect(caughtError).to.exist;
+                    });
+            });
+
+            it("Tests the proper header is sent", function () {
+                return SpokesService.fetchPipe(user, source)
+                    .then(function (payload: Spoke) {
+                        const args = fetchMock.lastCall()[1] as RequestInit;
+                        expect(args.headers["x-access-userid"]).to.equal(user.userId);
+                    });
+            });
+
             it("Tests the spoke returned by the service is correct.", function () {
-                return SpokesService.fetchPipe(source)
+                return SpokesService.fetchPipe(user, source)
                     .then(function (payload: Spoke) {
                         expect(payload).to.exist;
                         expect(payload.diagnosticKey).to.equal(fetchResponse.diagnosticKey);
@@ -115,6 +134,17 @@ describe("Spokes Service", function () {
                         expect(args.method).to.equal("POST");
                         expect(args.headers["Content-Type"]).to.equal("application/json");
                         expect(args.headers["x-access-userid"]).to.equal(user.userId);
+                    });
+            });
+
+            it("Tests that an error is thrown when an invalid user is not provided.", function () {
+                const copyUser = { ...user, ...{ userId: undefined } };
+                let caughtError: Error;
+                return SpokesService.savePipe(copyUser, source, { url: "http:spoke.url/" }, true)
+                    .catch(function (err: Error) {
+                        caughtError = err;
+                    }).then(function () {
+                        expect(caughtError).to.exist;
                     });
             });
 
@@ -199,9 +229,12 @@ describe("Spokes Service", function () {
             });
 
             it("Tests the promise rejects upon not found.", function () {
-                return SpokesService.fetchPipe(source)
+                let caughtError: Error;
+                return SpokesService.fetchPipe(user, source)
                     .catch(function (err: Error) {
-                        expect(err).to.exist;
+                        caughtError = err;
+                    }).then(function() {
+                        expect(caughtError).to.exist;
                     });
             });
         });
@@ -220,9 +253,12 @@ describe("Spokes Service", function () {
             });
 
             it("Tests the promise rejects upon not saved.", function () {
+                let caughtError: Error;
                 return SpokesService.savePipe(user, source, { lamdaARN: "testARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" }, true)
                     .catch(function (err: Error) {
-                        expect(err).to.exist;
+                        caughtError = err;
+                    }).then(function() {
+                        expect(caughtError).to.exist;
                     });
             });
         });
@@ -243,9 +279,12 @@ describe("Spokes Service", function () {
             });
 
             it("Tests the promise rejects upon network error..", function () {
-                return SpokesService.fetchPipe(source)
+                let caughtError: Error;
+                return SpokesService.fetchPipe(user, source)
                     .catch(function (err: Error) {
-                        expect(err).to.exist;
+                        caughtError = err;
+                    }).then(function() {
+                        expect(caughtError).to.exist;
                     });
             });
         });
@@ -264,9 +303,12 @@ describe("Spokes Service", function () {
             });
 
             it("Tests the promise rejects upon network error.", function () {
+                let caughtError: Error;
                 return SpokesService.savePipe(user, source, { lamdaARN: "testARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" }, true)
                     .catch(function (err: Error) {
-                        expect(err).to.exist;
+                        caughtError = err;
+                    }).then(function () {
+                        expect(caughtError).to.exist;
                     });
             });
         });

--- a/src/services/spokes.test.ts
+++ b/src/services/spokes.test.ts
@@ -211,6 +211,64 @@ describe("Spokes Service", function () {
                         expect((payload as any).http).to.not.exist;
                     });
             });
+
+            describe("Error checking", function () {
+                it("Tests that an error is thrown when user is undefined.", function () {
+                    let caughtError: Error;
+                    return SpokesService.savePipe(undefined, source, { url: "http:spoke.url/" }, true)
+                        .catch(function (err: Error) {
+                            caughtError = err;
+                        }).then(function () {
+                            expect(caughtError).to.exist;
+                        });
+                });
+
+                it("Tests that an error is thrown when source is undefined.", function () {
+                    const copyUser = { ...user };
+                    let caughtError: Error;
+                    return SpokesService.savePipe(copyUser, undefined, { url: "http:spoke.url/" }, true)
+                        .catch(function (err: Error) {
+                            caughtError = err;
+                        }).then(function () {
+                            expect(caughtError).to.exist;
+                        });
+                });
+
+                it("Tests that an error is thrown when source is undefined.", function () {
+                    const copyUser = { ...user };
+                    let caughtError: Error;
+                    return SpokesService.savePipe(copyUser, undefined, { url: "http:spoke.url/" }, true)
+                        .catch(function (err: Error) {
+                            caughtError = err;
+                        }).then(function () {
+                            expect(caughtError).to.exist;
+                        });
+                });
+
+                it("Tests that an error is thrown when source does not have a secret key.", function () {
+                    const copyUser = { ...user };
+                    const copySource = { ...source, ...{ secretKey: undefined } };
+                    let caughtError: Error;
+                    return SpokesService.savePipe(copyUser, copySource, { url: "http:spoke.url/" }, true)
+                        .catch(function (err: Error) {
+                            caughtError = err;
+                        }).then(function () {
+                            expect(caughtError).to.exist;
+                        });
+                });
+
+                it("Tests that an error is thrown when source does not have an ID.", function () {
+                    const copyUser = { ...user };
+                    const copySource = { ...source, ...{ id: undefined } };
+                    let caughtError: Error;
+                    return SpokesService.savePipe(copyUser, copySource, { url: "http:spoke.url/" }, true)
+                        .catch(function (err: Error) {
+                            caughtError = err;
+                        }).then(function () {
+                            expect(caughtError).to.exist;
+                        });
+                });
+            });
         });
     });
 
@@ -233,7 +291,7 @@ describe("Spokes Service", function () {
                 return SpokesService.fetchPipe(user, source)
                     .catch(function (err: Error) {
                         caughtError = err;
-                    }).then(function() {
+                    }).then(function () {
                         expect(caughtError).to.exist;
                     });
             });
@@ -257,7 +315,7 @@ describe("Spokes Service", function () {
                 return SpokesService.savePipe(user, source, { lambdaARN: "testARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" }, true)
                     .catch(function (err: Error) {
                         caughtError = err;
-                    }).then(function() {
+                    }).then(function () {
                         expect(caughtError).to.exist;
                     });
             });
@@ -283,7 +341,7 @@ describe("Spokes Service", function () {
                 return SpokesService.fetchPipe(user, source)
                     .catch(function (err: Error) {
                         caughtError = err;
-                    }).then(function() {
+                    }).then(function () {
                         expect(caughtError).to.exist;
                     });
             });

--- a/src/services/spokes.test.ts
+++ b/src/services/spokes.test.ts
@@ -23,10 +23,10 @@ const fetchResponse = {
         name: source.id
     },
     http: {
-        url: "https://source.url/" + source.id
+        url: "https://source.url/"
     },
     lambda: {
-        lamdaARN: "Lambda ARN",
+        lambdaARN: "Lambda ARN",
         awsAccessKey: "AWS Access Key",
         awsSecretKey: "AWS Secret Key"
     },
@@ -95,8 +95,8 @@ describe("Spokes Service", function () {
                         expect(payload.pipeType).to.equal(fetchResponse.pipeType);
                         expect(payload.path).to.equal(fetchResponse.path);
                         expect(payload.proxy).to.equal(fetchResponse.proxy);
-                        expect((payload as any).lambda).to.not.exist;
-                        expect((payload as any).http).to.not.exist;
+                        expect(payload.http).to.deep.equal(fetchResponse.http);
+                        expect((payload as Spoke).lambda.awsSecretKey).to.not.exist;
                     });
             });
         });
@@ -115,7 +115,7 @@ describe("Spokes Service", function () {
             });
 
             it("Tests the payload is returned upon successful save for http.", function () {
-                return SpokesService.savePipe(user, source, { url: "http:spoke.url/" }, true)
+                return SpokesService.savePipe(user, source, { url: "http://spoke.url/" }, true)
                     .then(function (payload: Spoke) {
                         expect(payload).to.exist;
                     });
@@ -129,7 +129,7 @@ describe("Spokes Service", function () {
             });
 
             it("Tests the proper header is sent", function () {
-                return SpokesService.savePipe(user, source, { url: "http:spoke.url/" }, true)
+                return SpokesService.savePipe(user, source, { url: "http://spoke.url/" }, true)
                     .then(function (payload: Spoke) {
                         const args = fetchMock.lastCall()[1] as RequestInit;
                         const headers = args.headers as any;
@@ -142,7 +142,7 @@ describe("Spokes Service", function () {
             it("Tests that an error is thrown when an invalid user is not provided.", function () {
                 const copyUser = { ...user, ...{ userId: undefined } };
                 let caughtError: Error;
-                return SpokesService.savePipe(copyUser, source, { url: "http:spoke.url/" }, true)
+                return SpokesService.savePipe(copyUser, source, { url: "http://spoke.url/" }, true)
                     .catch(function (err: Error) {
                         caughtError = err;
                     }).then(function () {
@@ -151,7 +151,7 @@ describe("Spokes Service", function () {
             });
 
             it("Tests the proper post object was sent by the service is correct for HTTP.", function () {
-                return SpokesService.savePipe(user, source, { url: "http:spoke.url/" }, true)
+                return SpokesService.savePipe(user, source, { url: "http://spoke.url/" }, true)
                     .then(function (payload: Spoke) {
                         const args = fetchMock.lastCall()[1] as RequestInit;
                         const reqObj = JSON.parse(args.body);
@@ -162,7 +162,7 @@ describe("Spokes Service", function () {
                         expect(reqObj.pipeType).to.equal("HTTP");
                         expect(reqObj.path).to.equal("/");
                         expect(reqObj.proxy).to.equal(true);
-                        expect(reqObj.http).to.deep.equal({ url: "http:spoke.url/" });
+                        expect(reqObj.http).to.deep.equal({ url: "http://spoke.url/" });
                         expect(reqObj.lambda).to.not.exist;
                     });
             });
@@ -179,13 +179,13 @@ describe("Spokes Service", function () {
                         expect(reqObj.pipeType).to.equal("LAMBDA");
                         expect(reqObj.path).to.equal("/");
                         expect(reqObj.proxy).to.equal(true);
-                        expect(reqObj.lambda).to.deep.equal({ lamdaARN: "testARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" });
+                        expect(reqObj.lambda).to.deep.equal({ lambdaARN: "testARN", awsAccessKey: "ABC123", awsSecretKey: "123ABC" });
                         expect(reqObj.http).to.not.exist;
                     });
             });
 
             it("Tests the Spoke returned by the service is correct for HTTP.", function () {
-                return SpokesService.savePipe(user, source, { url: "http:spoke.url/" }, true)
+                return SpokesService.savePipe(user, source, { url: "http://spoke.url/" }, true)
                     .then(function (payload: Spoke) {
                         expect(payload).to.exist;
                         expect(payload.diagnosticKey).to.equal(fetchResponse.diagnosticKey);
@@ -194,8 +194,8 @@ describe("Spokes Service", function () {
                         expect(payload.pipeType).to.equal(fetchResponse.pipeType);
                         expect(payload.proxy).to.equal(fetchResponse.proxy);
                         expect(payload.path).to.equal("/"); // This is always "/" currently in the API.
+                        expect(payload.http).to.deep.equal({ url: "http://spoke.url/" });
                         expect((payload as any).lambda).to.not.exist;
-                        expect((payload as any).http).to.not.exist;
                     });
             });
 
@@ -209,7 +209,7 @@ describe("Spokes Service", function () {
                         expect(payload.proxy).to.equal(fetchResponse.proxy);
                         expect(payload.path).to.equal("/"); // This is always "/" currently in the API.
                         expect(payload.pipeType).to.equal("LAMBDA");
-                        expect((payload as any).lambda).to.not.exist;
+                        expect(payload.lambda).to.deep.equal({ lambdaARN: "testARN", awsAccessKey: "ABC123", awsSecretKey: undefined});
                         expect((payload as any).http).to.not.exist;
                     });
             });
@@ -217,7 +217,7 @@ describe("Spokes Service", function () {
             describe("Error checking", function () {
                 it("Tests that an error is thrown when user is undefined.", function () {
                     let caughtError: Error;
-                    return SpokesService.savePipe(undefined, source, { url: "http:spoke.url/" }, true)
+                    return SpokesService.savePipe(undefined, source, { url: "http://spoke.url/" }, true)
                         .catch(function (err: Error) {
                             caughtError = err;
                         }).then(function () {
@@ -228,7 +228,7 @@ describe("Spokes Service", function () {
                 it("Tests that an error is thrown when source is undefined.", function () {
                     const copyUser = { ...user };
                     let caughtError: Error;
-                    return SpokesService.savePipe(copyUser, undefined, { url: "http:spoke.url/" }, true)
+                    return SpokesService.savePipe(copyUser, undefined, { url: "http://spoke.url/" }, true)
                         .catch(function (err: Error) {
                             caughtError = err;
                         }).then(function () {
@@ -239,7 +239,7 @@ describe("Spokes Service", function () {
                 it("Tests that an error is thrown when source is undefined.", function () {
                     const copyUser = { ...user };
                     let caughtError: Error;
-                    return SpokesService.savePipe(copyUser, undefined, { url: "http:spoke.url/" }, true)
+                    return SpokesService.savePipe(copyUser, undefined, { url: "http://spoke.url/" }, true)
                         .catch(function (err: Error) {
                             caughtError = err;
                         }).then(function () {
@@ -251,7 +251,7 @@ describe("Spokes Service", function () {
                     const copyUser = { ...user };
                     const copySource = { ...source, ...{ secretKey: undefined } };
                     let caughtError: Error;
-                    return SpokesService.savePipe(copyUser, copySource, { url: "http:spoke.url/" }, true)
+                    return SpokesService.savePipe(copyUser, copySource, { url: "http://spoke.url/" }, true)
                         .catch(function (err: Error) {
                             caughtError = err;
                         }).then(function () {
@@ -263,7 +263,7 @@ describe("Spokes Service", function () {
                     const copyUser = { ...user };
                     const copySource = { ...source, ...{ id: undefined } };
                     let caughtError: Error;
-                    return SpokesService.savePipe(copyUser, copySource, { url: "http:spoke.url/" }, true)
+                    return SpokesService.savePipe(copyUser, copySource, { url: "http://spoke.url/" }, true)
                         .catch(function (err: Error) {
                             caughtError = err;
                         }).then(function () {

--- a/src/services/spokes.ts
+++ b/src/services/spokes.ts
@@ -28,7 +28,7 @@ namespace spokes {
                 return fetch(URL, {
                     headers: {
                         "x-access-userid": user.userId,
-                        "x-access-token": ""
+                        "x-access-token": "4772616365-46696f72656c6c61",
                     }
                 });
             }).then(function (result: Response) {
@@ -64,7 +64,7 @@ namespace spokes {
                     method: "POST",
                     headers: {
                         "Content-Type": "application/json",
-                        "x-access-token": "",
+                        "x-access-token": "4772616365-46696f72656c6c61",
                         "x-access-userid": user.userId
                     },
                     body: JSON.stringify(postObj)
@@ -94,7 +94,7 @@ function resolveUser(user: User): Promise<User> {
         if (user.userId) {
             resolve(user);
         } else {
-            reject(new Error("User must have a valie user ID"));
+            reject(new Error("User must have a valid user ID"));
         }
     });
 }

--- a/src/services/spokes.ts
+++ b/src/services/spokes.ts
@@ -25,11 +25,12 @@ namespace spokes {
         const URL = BASE_URL + "/pipe/" + source.secretKey;
         return resolveUser(user)
             .then(function (user: User) {
-                return fetch(URL, {
-                    headers: {
+                const headers: Headers = new Headers({
                         "x-access-userid": user.userId,
                         "x-access-token": "Test Key"
-                    }
+                    });
+                return fetch(URL, {
+                    headers: headers
                 });
             }).then(function (result: Response) {
                 return parse(result, "Spoke not found.");
@@ -57,24 +58,31 @@ namespace spokes {
         let postObj: SaveSpokeRequestObj;
         return resolveSource(source)
             .then(function (source: Source) {
-                 postObj = new SaveSpokeRequestObj(source, resource, liveDebugging);
+                postObj = new SaveSpokeRequestObj(source, resource, liveDebugging);
                 return resolveUser(user);
             }).then(function (user: User) {
+                const headers = new Headers({
+                        "Content-Type": "application/json",
+                        "x-access-token": "4772616365-46696f72656c6c61",
+                        "x-access-userid": user.userId
+                    });
                 return fetch(URL, {
                     method: "POST",
-                    headers: {
-                        "Content-Type": "application/json",
-                        "x-access-token": "Test Key",
-                        "x-access-userid": user.userId
-                    }, body: JSON.stringify(postObj)
+                    headers: headers,
+                    body: JSON.stringify(postObj)
                 });
             }).then(function (result: Response) {
+                console.info("Return " + result.status);
+                console.log(result);
                 scrub(postObj);
                 if (result.status === 200) {
                     return new FetchSpokeResponseObj(postObj);
                 } else {
                     return Promise.reject("Could not save spoke.");
                 }
+            }).catch(function(err: Error) {
+                console.error(err);
+                throw err;
             });
     }
 }

--- a/src/services/spokes.ts
+++ b/src/services/spokes.ts
@@ -42,10 +42,7 @@ namespace spokes {
 
     function parse<T>(result: Response, errMsg: string = "Could not parse result."): T | Thenable<T> {
         if (result.status === 200) {
-            return result.json().then(function(result: any) {
-                console.log(result);
-                return result;
-            });
+            return result.json();
         } else {
             return Promise.reject(new Error(errMsg));
         }
@@ -73,8 +70,6 @@ namespace spokes {
                     body: JSON.stringify(postObj)
                 });
             }).then(function (result: Response) {
-                console.info("Return " + result.status);
-                console.log(result);
                 scrub(postObj);
                 if (result.status === 200) {
                     return new FetchSpokeResponseObj(postObj);

--- a/src/services/spokes.ts
+++ b/src/services/spokes.ts
@@ -28,7 +28,7 @@ namespace spokes {
                 return fetch(URL, {
                     headers: {
                         "x-access-userid": user.userId,
-                        "x-access-token": "Test token"
+                        "x-access-token": "Test Key"
                     }
                 });
             }).then(function (result: Response) {
@@ -64,7 +64,7 @@ namespace spokes {
                     method: "POST",
                     headers: {
                         "Content-Type": "application/json",
-                        "x-access-token": "Test token",
+                        "x-access-token": "Test Key",
                         "x-access-userid": user.userId
                     }, body: JSON.stringify(postObj)
                 });

--- a/src/services/spokes.ts
+++ b/src/services/spokes.ts
@@ -2,6 +2,7 @@ import "isomorphic-fetch";
 
 import Source from "../models/source";
 import * as Spoke from "../models/spoke";
+import User from "../models/User";
 
 namespace spokes {
 
@@ -39,14 +40,15 @@ namespace spokes {
      * creates a Spokes pipe which can be later retrieved from `fetchPipe`.
      * @param secret
      */
-    export function savePipe(source: Source, resource: HTTP | Lambda, liveDebugging: boolean): Promise<Spoke.Spoke> {
+    export function savePipe(user: User, source: Source, resource: HTTP | Lambda, liveDebugging: boolean): Promise<Spoke.Spoke> {
         const URL = BASE_URL + "/pipe";
         const postObj = new SaveSpokeRequestObj(source, resource, liveDebugging);
         return fetch(URL, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
-                "x-access-token": "Test Key"
+                "x-access-token": "Test Key",
+                "x-access-userid": user.userId
             }, body: JSON.stringify(postObj)
         }).then(function (result: Response) {
                 scrub(postObj);

--- a/src/services/spokes.ts
+++ b/src/services/spokes.ts
@@ -53,10 +53,12 @@ namespace spokes {
      */
     export function savePipe(user: User, source: Source, resource: HTTP | Lambda, liveDebugging: boolean): Promise<Spoke.Spoke> {
         const URL = BASE_URL + "/pipe";
-        const postObj = new SaveSpokeRequestObj(source, resource, liveDebugging);
-        return resolveUser(user)
-            .then(function (user: User) {
-                console.info("userID " + user.userId);
+        let postObj: SaveSpokeRequestObj;
+        return resolveSource(source)
+            .then(function (source: Source) {
+                 postObj = new SaveSpokeRequestObj(source, resource, liveDebugging);
+                return resolveUser(user);
+            }).then(function (user: User) {
                 return fetch(URL, {
                     method: "POST",
                     headers: {
@@ -66,8 +68,6 @@ namespace spokes {
                     }, body: JSON.stringify(postObj)
                 });
             }).then(function (result: Response) {
-                console.info(result.status);
-                console.log(postObj);
                 scrub(postObj);
                 if (result.status === 200) {
                     return new FetchSpokeResponseObj(postObj);
@@ -88,6 +88,16 @@ function resolveUser(user: User): Promise<User> {
             resolve(user);
         } else {
             reject(new Error("User must have a valie user ID"));
+        }
+    });
+}
+
+function resolveSource(source: Source): Promise<Source> {
+    return new Promise((resolve: (obj: Source) => void, reject: (err: Error) => void) => {
+        if (!source || !source.secretKey || !source.id) {
+            return reject(new Error("Source must be provided with key and id."));
+        } else {
+            return resolve(source);
         }
     });
 }

--- a/src/services/spokes.ts
+++ b/src/services/spokes.ts
@@ -27,7 +27,8 @@ namespace spokes {
             .then(function (user: User) {
                 return fetch(URL, {
                     headers: {
-                        "x-access-userid": user.userId
+                        "x-access-userid": user.userId,
+                        "x-access-token": "Test token"
                     }
                 });
             }).then(function (result: Response) {
@@ -63,7 +64,7 @@ namespace spokes {
                     method: "POST",
                     headers: {
                         "Content-Type": "application/json",
-                        "x-access-token": "Test Key",
+                        "x-access-token": "Test token",
                         "x-access-userid": user.userId
                     }, body: JSON.stringify(postObj)
                 });

--- a/src/services/spokes.ts
+++ b/src/services/spokes.ts
@@ -56,6 +56,7 @@ namespace spokes {
         const postObj = new SaveSpokeRequestObj(source, resource, liveDebugging);
         return resolveUser(user)
             .then(function (user: User) {
+                console.info("userID " + user.userId);
                 return fetch(URL, {
                     method: "POST",
                     headers: {
@@ -65,6 +66,8 @@ namespace spokes {
                     }, body: JSON.stringify(postObj)
                 });
             }).then(function (result: Response) {
+                console.info(result.status);
+                console.log(postObj);
                 scrub(postObj);
                 if (result.status === 200) {
                     return new FetchSpokeResponseObj(postObj);

--- a/src/services/spokes.ts
+++ b/src/services/spokes.ts
@@ -2,7 +2,7 @@ import "isomorphic-fetch";
 
 import Source from "../models/source";
 import * as Spoke from "../models/spoke";
-import User from "../models/User";
+import User from "../models/user";
 
 namespace spokes {
 

--- a/src/services/spokes.ts
+++ b/src/services/spokes.ts
@@ -9,7 +9,7 @@ namespace spokes {
     const BASE_URL = "https://api.bespoken.link";
 
     export interface Lambda {
-        lamdaARN: string;
+        lambdaARN: string;
         awsAccessKey: string;
         awsSecretKey: string;
     };
@@ -238,11 +238,11 @@ class SaveSpokeRequestObj implements SaveRequest {
             this.http = {
                 url: res.url
             };
-        } else if ((resource as spokes.Lambda).lamdaARN) {
+        } else if ((resource as spokes.Lambda).lambdaARN) {
             this.pipeType = "LAMBDA";
             const res = resource as spokes.Lambda;
             this.lambda = {
-                lamdaARN: res.lamdaARN,
+                lamdaARN: res.lambdaARN,
                 awsAccessKey: res.awsAccessKey,
                 awsSecretKey: res.awsSecretKey
             };

--- a/src/services/spokes.ts
+++ b/src/services/spokes.ts
@@ -25,12 +25,11 @@ namespace spokes {
         const URL = BASE_URL + "/pipe/" + source.secretKey;
         return resolveUser(user)
             .then(function (user: User) {
-                const headers: Headers = new Headers({
-                        "x-access-userid": user.userId,
-                        "x-access-token": "Test Key"
-                    });
                 return fetch(URL, {
-                    headers: headers
+                    headers: {
+                        "x-access-userid": user.userId,
+                        "x-access-token": ""
+                    }
                 });
             }).then(function (result: Response) {
                 return parse(result, "Spoke not found.");
@@ -61,14 +60,13 @@ namespace spokes {
                 postObj = new SaveSpokeRequestObj(source, resource, liveDebugging);
                 return resolveUser(user);
             }).then(function (user: User) {
-                const headers = new Headers({
-                        "Content-Type": "application/json",
-                        "x-access-token": "4772616365-46696f72656c6c61",
-                        "x-access-userid": user.userId
-                    });
                 return fetch(URL, {
                     method: "POST",
-                    headers: headers,
+                    headers: {
+                        "Content-Type": "application/json",
+                        "x-access-token": "",
+                        "x-access-userid": user.userId
+                    },
                     body: JSON.stringify(postObj)
                 });
             }).then(function (result: Response) {

--- a/src/services/spokes.ts
+++ b/src/services/spokes.ts
@@ -1,0 +1,231 @@
+import "isomorphic-fetch";
+
+import Source from "../models/source";
+import * as Spoke from "../models/spoke";
+
+namespace spokes {
+
+    const BASE_URL = "https://api.bespoken.link";
+
+    export interface Lambda {
+        lamdaARN: string;
+        awsAccessKey: string;
+        awsSecretKey: string;
+    };
+
+    export interface HTTP {
+        url: string;
+    }
+
+    /**
+     * Returns a payload about the specified Pipe.
+     */
+    export function fetchPipe(source: Source): Promise<Spoke.Spoke> {
+        const URL = BASE_URL + "/pipe/" + source.secretKey;
+        return fetch(URL)
+            .then(function (result: Response) {
+                if (result.status === 200) {
+                    return result.json();
+                } else {
+                    return Promise.reject(new Error("Spoke not found."));
+                }
+            }).then(function (result: FetchSpokeResponse) {
+                scrub(result);
+                return new FetchSpokeResponseObj(result);
+            });
+    }
+
+    /**
+     * creates a Spokes pipe which can be later retrieved from `fetchPipe`.
+     * @param secret
+     */
+    export function savePipe(source: Source, resource: HTTP | Lambda, liveDebugging: boolean): Promise<Spoke.Spoke> {
+        const URL = BASE_URL + "/pipe";
+        const postObj = new SaveSpokeRequestObj(source, resource, liveDebugging);
+        return fetch(URL, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "x-access-token": "Test Key"
+            }, body: JSON.stringify(postObj)
+        }).then(function (result: Response) {
+                scrub(postObj);
+                if (result.status === 200) {
+                    return new FetchSpokeResponseObj(postObj);
+                } else {
+                    return Promise.reject("Could not save spoke.");
+                }
+            });
+    }
+}
+
+export default spokes;
+
+type PIPE_TYPE = Spoke.PIPE_TYPE;
+
+interface FetchSpokeResponse {
+    /**
+     * Secret key of the skill.
+     */
+    uuid: string;
+    /**
+     * A unique diagnostic key for the skill. Currently the same as the secret key.
+     */
+    diagnosticKey: string;
+    /**
+     * The location that the skill would be retrieved from.
+     */
+    endPoint: {
+        /**
+         * Skill ID.
+         */
+        name: string;
+    };
+    /**
+     * Spokes http endpoint
+     */
+    http?: {
+        url: string;
+    };
+    /**
+     * Spokes Lamda endpoint
+     */
+    lambda?: {
+        lamdaARN: string;
+        awsAccessKey: string;
+        awsSecretKey: string;
+    };
+    /**
+     * Location to the pipe.
+     */
+    path: string;
+    /**
+     * Type of pipe this is.
+     */
+    pipeType: PIPE_TYPE;
+    /**
+     * True or false based on whether live debugging is enabled.
+     */
+    proxy: boolean;
+}
+
+interface SaveRequest {
+    /**
+     * Secret key of the skill.
+     */
+    uuid: string;
+    /**
+     * A unique diagnostic key for the skill. Currently the same as the secret key.
+     */
+    diagnosticKey: string;
+    /**
+     * The location that the skill would be retrieved from.
+     */
+    endPoint: {
+        /**
+         * Skill ID.
+         */
+        name: string;
+    };
+    /**
+     * Spokes http endpoint
+     */
+    http?: {
+        url: string;
+    };
+    /**
+     * Spokes Lamda endpoint
+     */
+    lambda?: {
+        lamdaARN: string;
+        awsAccessKey: string;
+        awsSecretKey: string;
+    };
+    /**
+     * Location to the pipe.
+     */
+    path: string;
+    /**
+     * Type of pipe this is.
+     */
+    pipeType: PIPE_TYPE;
+    /**
+     * True or false based on whether live debugging is enabled.
+     */
+    proxy: boolean;
+}
+
+/**
+ * Removes objects from memory that we don't want.
+ * @param response Removes object
+ */
+function scrub(response: FetchSpokeResponse | SaveRequest): void {
+    response.lambda = undefined;
+    response.http = undefined;
+}
+
+/**
+ * There are certian items in the response that we do not want to keep in memory long (i.e. access keys).
+ * So scrube those out.
+ */
+class FetchSpokeResponseObj implements Spoke.Spoke {
+    uuid: string;
+    diagnosticKey: string;
+    endPoint: {
+        name: string;
+    };
+    path: string;
+    pipeType: PIPE_TYPE;
+    proxy: boolean;
+
+    constructor(response: FetchSpokeResponse | SaveSpokeRequestObj) {
+        this.uuid = response.uuid;
+        this.diagnosticKey = response.diagnosticKey;
+        this.endPoint = response.endPoint;
+        this.path = response.path;
+        this.pipeType = response.pipeType;
+        this.proxy = response.proxy;
+    }
+}
+
+class SaveSpokeRequestObj implements SaveRequest {
+    uuid: string;
+    diagnosticKey: string;
+    endPoint: {
+        name: string;
+    };
+    http?: {
+        url: string;
+    };
+    lambda?: {
+        lamdaARN: string;
+        awsAccessKey: string;
+        awsSecretKey: string;
+    };
+    path: string;
+    pipeType: PIPE_TYPE;
+    proxy: boolean;
+
+    constructor(source: Source, resource: spokes.HTTP | spokes.Lambda, proxy: boolean = false) {
+        this.uuid = source.secretKey;
+        this.diagnosticKey = source.secretKey;
+        this.endPoint = { name: source.id };
+        this.path = "/"; // always this for now.
+        this.proxy = proxy;
+        if ((resource as spokes.HTTP).url) {
+            this.pipeType = "HTTP";
+            const res = resource as spokes.HTTP;
+            this.http = {
+                url: res.url
+            };
+        } else if ((resource as spokes.Lambda).lamdaARN) {
+            this.pipeType = "LAMBDA";
+            const res = resource as spokes.Lambda;
+            this.lambda = {
+                lamdaARN: res.lamdaARN,
+                awsAccessKey: res.awsAccessKey,
+                awsSecretKey: res.awsSecretKey
+            };
+        }
+    }
+}

--- a/src/themes/input-config.scss
+++ b/src/themes/input-config.scss
@@ -1,0 +1,11 @@
+@import "dashboard";
+@import "~react-toolbox/lib/input/config";
+
+$input-padding-bottom: 0;
+$input-padding-top: 0.7em;
+$input-filled-padding-bottom: 0.35em;
+$input-filled-padding-top: $input-filled-padding-bottom;
+
+$label-top: 1.3em;
+$label-filled-padding-top: 0;
+$label-filled-padding-left: 0;

--- a/src/themes/input-theme.scss
+++ b/src/themes/input-theme.scss
@@ -1,0 +1,40 @@
+@import "./input-config.scss"
+
+.inputElement {
+    &:focus:not([disabled]):not([readonly]), &.filled {
+            padding-bottom: $input-filled-padding-bottom;
+            padding-top: $input-filled-padding-top;
+
+        ~ .label:not(.fixed) {
+            top: $label-filled-padding-top;
+            padding-left: $label-filled-padding-left;
+            font-size: $label-font-size-active;
+        }
+    }
+}
+
+.input {
+    padding-top: 1em;
+    padding-bottom: 0
+}
+
+.input:not(.disabled) > .inputElement {
+    font-size: $input-font-size;
+    color: $input-color-light;
+    padding-bottom: $input-padding-bottom;
+    padding-top: $input-padding-top;
+    transition-property: top, font-size, color, padding;
+
+    &:focus,
+    &.filled {
+        padding-bottom: $input-filled-padding-bottom;
+        padding-top: $input-filled-padding-top;
+    }
+}
+
+.label {
+    font-size: $label-font-size;
+    color: $label-color-light;
+    top: $label-top;
+    transition-property: top, font-size, color, padding;
+}


### PR DESCRIPTION
Fixes #238 
Fixes #239

Changes in this pull request include:
- Currently allows user to set the spokes for both HTTP and Lambda. 

NOTES:
Bugs:
- Because the Spokes integration currently requires an access key, it is impossible using the current source code to actually save the spoke. This key is not saved on source control. It must be added manually by source code

Future additions:

- Ability to retrieve the Spoke so the user "just sees" it when they've previously saved it.