### PR TITLE
src: renames `Home` to `Action` on skill chart's legend

### DIFF
--- a/src/pages/sourcepage/SourceFullSummary.tsx
+++ b/src/pages/sourcepage/SourceFullSummary.tsx
@@ -71,7 +71,7 @@ export class SourceFullSummary extends React.Component<SourceFullSummaryProps, S
         },
         "Google": {
             dataKey: "Google.Home",
-            name: "Home",
+            name: "Action",
             stroke: GOOGLE_GREEN
         }
     };
@@ -85,7 +85,7 @@ export class SourceFullSummary extends React.Component<SourceFullSummaryProps, S
         },
         "Google": {
             dataKey: "Google.Home",
-            name: "Home",
+            name: "Action",
             fill: GOOGLE_GREEN,
             stackId: "a"
         }


### PR DESCRIPTION
Fixes #304 

Changes in this pull request include:
- Renames `Home` to `Action`
